### PR TITLE
[FE] 트림 박스 컨테이너 구현

### DIFF
--- a/frontend/Idle/src/components/TrimBoxContainer/TrimBoxContainer.jsx
+++ b/frontend/Idle/src/components/TrimBoxContainer/TrimBoxContainer.jsx
@@ -1,0 +1,21 @@
+import { styled } from "styled-components";
+import NormalTrimBox from "../common/NormalTrimBox";
+
+// eslint-disable-next-line react/prop-types
+function TrimBoxContainer(data) {
+  return (
+    <StContainer>
+      {data.trim.map((item, idx) => (
+        <NormalTrimBox key={idx} {...item} />
+      ))}
+    </StContainer>
+  );
+}
+
+export default TrimBoxContainer;
+
+const StContainer = styled.div`
+  display: inline-flex;
+  align-items: flex-start;
+  gap: 8px;
+`;

--- a/frontend/Idle/src/components/common/NormalTrimBox.jsx
+++ b/frontend/Idle/src/components/common/NormalTrimBox.jsx
@@ -4,7 +4,7 @@ import { useContext } from "react";
 import carContext from "../../../utils/carContext";
 
 // eslint-disable-next-line react/prop-types
-function NormalTrimBox({ usage, title, detail, price, isActive = true }) {
+function NormalTrimBox({ purchase_rate, name, desc, price, isActive = true }) {
   const { car, setCar } = useContext(carContext);
 
   function trimClicked(name) {
@@ -19,23 +19,23 @@ function NormalTrimBox({ usage, title, detail, price, isActive = true }) {
     }
   }
 
-  const isTrimSelected = car.trim.name === title;
+  const isTrimSelected = car.trim.name === name;
 
   return (
     <StContainer
-      onClick={() => trimClicked(title)}
+      onClick={() => trimClicked(name)}
       $isSelected={isTrimSelected}
       $isActive={isActive}
     >
       <StContent>
         <StTitleContainer>
           <StContentHeader>
-            <TitleDetail $isSelected={isTrimSelected}>{usage}</TitleDetail>
-            <Title $isSelected={isTrimSelected}>{title}</Title>
+            <TitleDetail $isSelected={isTrimSelected}>{purchase_rate}</TitleDetail>
+            <Title $isSelected={isTrimSelected}>{name}</Title>
           </StContentHeader>
-          <Detail $isSelected={isTrimSelected}>{detail}</Detail>
+          <Detail $isSelected={isTrimSelected}>{desc}</Detail>
         </StTitleContainer>
-        <Price $isSelected={isTrimSelected}>{price} 원</Price>
+        <Price $isSelected={isTrimSelected}>{price.toLocaleString()} 원</Price>
       </StContent>
       <PopUpButton $isSelected={isTrimSelected}>
         자세히 보기

--- a/frontend/Idle/src/pages/trimPage.jsx
+++ b/frontend/Idle/src/pages/trimPage.jsx
@@ -1,8 +1,17 @@
+import { useEffect, useState } from "react";
+import { getTrimData } from "../../utils/api";
+import TrimBoxContainer from "../components/TrimBoxContainer/TrimBoxContainer";
+
 function TrimPage() {
-  return (
-    <div>
-    </div>
-  );
+  const [trimData, setTrimData] = useState(null);
+
+  useEffect(() => {
+    getTrimData().then((result) => {
+      setTrimData(result);
+    });
+  }, []);
+
+  return <div>{trimData ? <TrimBoxContainer {...trimData} /> : <p>Loading...</p>}</div>;
 }
 
 export default TrimPage;

--- a/frontend/Idle/utils/api.jsx
+++ b/frontend/Idle/utils/api.jsx
@@ -1,0 +1,13 @@
+export async function getTrimData() {
+  try {
+    const response = await fetch("../utils/dummydata/trim.json")
+      .then((response) => response.json())
+      .then((json) => {
+        return json;
+      });
+    return response;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+}

--- a/frontend/Idle/utils/dummydata/trim.json
+++ b/frontend/Idle/utils/dummydata/trim.json
@@ -1,0 +1,99 @@
+{
+  "trim": [
+    {
+      "trim_idx": 1,
+      "name": "Exclusive",
+      "desc": "실용적이고 기본적인 기능을 갖춘 베이직 트림",
+      "price": 40440000,
+      "img_url": "...",
+      "purchase_rate": 22.2,
+      "default_func": [
+        {
+          "function_idx": 444444,
+          "name": "디젤2.2엔진",
+          "categori_idx": 222222
+        },
+        {
+          "function_idx": 555555,
+          "name": "에어백",
+          "category_idx": 333333
+        },
+        {}
+      ]
+    },
+    {
+      "trim_idx": 2,
+      "name": "Le Blanc",
+      "desc": "실용적이고 기본적인 기능을 갖춘 베이직 트림 ",
+      "price": 43460000,
+      "img_url": "...",
+      "purchase_rate": 22.2,
+      "default_func": [
+        {
+          "function_idx": 444444,
+          "name": "디젤2.2엔진",
+          "category_idx": 222222
+        },
+        {
+          "function_idx": 555555,
+          "name": "에어백",
+          "category_idx": 333333
+        },
+        {}
+      ]
+    },
+    {
+      "trim_idx": 3,
+      "name": "Prestige",
+      "desc": "실용적이고 기본적인 기능을 갖춘 베이직 트림 ",
+      "price": 47720000,
+      "img_url": "...",
+      "purchase_rate": 22.2,
+      "default_func": [
+        {
+          "function_idx": 444444,
+          "name": "디젤2.2엔진",
+          "category_idx": 222222
+        },
+        {
+          "function_idx": 555555,
+          "name": "에어백",
+          "category_idx": 333333
+        },
+        {}
+      ]
+    },
+    {
+      "trim_idx": 4,
+      "name": "Calligraphy",
+      "desc": "실용적이고 기본적인 기능을 갖춘 베이직 트림 ",
+      "price": 52540000,
+      "img_url": "...",
+      "purchase_rate": 22.2,
+      "default_func": [
+        {
+          "function_idx": 444444,
+          "name": "디젤2.2엔진",
+          "category_idx": 222222
+        },
+        {
+          "function_idx": 555555,
+          "name": "에어백",
+          "category_idx": 333333
+        },
+        {}
+      ]
+    }
+  ],
+  "category": [
+    {
+      "function_category_idx": 222222,
+      "name": "파워트레인/성능"
+    },
+    {
+      "function_category_idx": 333333,
+      "name": "안전"
+    },
+    {}
+  ]
+}


### PR DESCRIPTION
## 🚩 관련 이슈
- close #25 

## 📋 구현 기능 명세
- [x] 받아온 트림 리스트로 트림박스 생성
- [x] 기본 상태 0번째 트림박스 true 로 설정
- [x] 각 트림박스에 대한 클릭 이벤트 함수 전달
- [x] 클릭 이벤트 함수 - 차 객체에 옵션이 있는지 확인하는 함수로 체크 + 더듬이 이미지 변경

## 📌 PR Point
- 트림 선택 페이지에서 사용할 api 명세서에 따른 더미 데이터 json 파일 추가
- json 파일과의 fetch 통신 구현
- trimPage에서 통신 후 트림 박스 렌더링
- 트림 변경에 대한 경고 모달은 아직 미구현

## 📸 결과물 스크린샷
<img width="853" alt="스크린샷 2023-08-04 오전 10 15 19" src="https://github.com/softeerbootcamp-2nd/A5-Idle/assets/39405559/12535406-310d-461b-a2b7-b326868c9846">
