### PR TITLE
[FE] 카테고리 탭 컴포넌트 구현 

### DIFF
--- a/frontend/Idle/src/components/common/tabs/CategoryTabs.jsx
+++ b/frontend/Idle/src/components/common/tabs/CategoryTabs.jsx
@@ -1,0 +1,29 @@
+import { styled } from "styled-components"
+
+function CategoryTabs({ text, onClick, isClicked = false }) {
+    return (
+        <StContainer onClick={onClick} $isClicked={isClicked}>
+            {text}
+        </StContainer>
+    )
+}
+
+export default CategoryTabs
+
+const StContainer = styled.div`
+    display: flex;
+    padding: 3px 0px 5px 0px;
+    border-bottom: ${({ $isClicked }) => $isClicked ? "2px solid #1A3276" : ""};
+    justify-content: center;
+    align-items: center;
+    color: ${({ $isClicked }) => $isClicked ? "#1A3276" : "#C5C9D2"};
+    text-align: center;
+
+    /* body1 medium */
+    font-family: "Hyundai Sans Text KR";
+    font-size: 16px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 24px;
+    letter-spacing: -0.48px;
+`

--- a/frontend/Idle/src/pages/detailModelPage.jsx
+++ b/frontend/Idle/src/pages/detailModelPage.jsx
@@ -3,8 +3,9 @@ import DetailModelBox from "../components/common/boxs/DetailModelBox";
 import { styled } from "styled-components";
 import { useNavigate } from "react-router-dom";
 import BlueButton from "../components/common/buttons/BlueButton";
-import { TRANSLATE } from "../utils/constants";
+import { BODY_TYPES, DRVING_METHODS, ENGINES, TRANSLATE } from "../utils/constants";
 import WhiteButton from "../components/common/buttons/WhiteButton";
+import CategoryTabs from "../components/common/tabs/CategoryTabs";
 
 const dummyData = {
   "engines": [
@@ -72,40 +73,34 @@ const dummyData = {
 }
 
 function DetailModelPage() {
-  const [currentTab, setCurrentTab] = useState("engines")
+  const [currentTab, setCurrentTab] = useState(ENGINES)
   const navigate = useNavigate();
+  const tabs = [ENGINES, DRVING_METHODS, BODY_TYPES];
 
-  function nextBTNClicked() {
-    switch (currentTab) {
-      case "engines":
-        setCurrentTab("driving_methods")
-        break
-      case "driving_methods":
-        setCurrentTab("body_types")
-        break
-      case "body_types":
+  function handleTabChange(direction) {
+    const currentIndex = tabs.indexOf(currentTab);
+
+    if (direction === "next") {
+      if (currentIndex !== -1 && currentIndex + 1 < tabs.length) {
+        setCurrentTab(tabs[currentIndex + 1]);
+      } else {
         navigate("/color");
-        break
-    }
-  }
-  function prevBTNClicked() {
-    switch (currentTab) {
-      case "engines":
-        navigate(-1)
-        break
-      case "driving_methods":
-        setCurrentTab("engines")
-        break
-      case "body_types":
-        setCurrentTab("driving_methods")
-        break
+      }
+    } else if (direction === "prev") {
+      if (currentIndex > 0) {
+        setCurrentTab(tabs[currentIndex - 1]);
+      } else {
+        navigate("/trim");
+      }
     }
   }
 
   return (
     <>
-
       <StWrapper>
+        <StTabContainer>
+          {tabs.map((item, idx) => (<CategoryTabs key={idx} text={TRANSLATE[item]} isClicked={item === currentTab} />))}
+        </StTabContainer>
         <StBottomContainer>
           <StContainer>
             {dummyData[currentTab].map((item, idx) => (<DetailModelBox key={idx} {...item} currentTab={currentTab} />))}
@@ -113,11 +108,11 @@ function DetailModelPage() {
           <StConfirmContainer>
             <StConfirmHeader>
               <Title>{TRANSLATE[currentTab]} 선택</Title>
-              <Description>원하는 {TRANSLATE[currentTab]} 을 선택해주세요.</Description>
+              <Description>원하는 {TRANSLATE[currentTab]}을 선택해주세요.</Description>
             </StConfirmHeader>
             <StButtonContainer>
-              <WhiteButton text={"이전"} onClick={prevBTNClicked} />
-              <BlueButton text={"다음"} onClick={nextBTNClicked} />
+              <WhiteButton text={"이전"} onClick={() => { handleTabChange("prev") }} />
+              <BlueButton text={"다음"} onClick={() => { handleTabChange("next") }} />
             </StButtonContainer>
           </StConfirmContainer>
         </StBottomContainer>
@@ -145,7 +140,6 @@ const StBottomContainer = styled.div`
   display: flex;
   gap: 46px;
   bottom: 64px;
-  left: 128px;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -170,7 +164,6 @@ const StButtonContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 4px;
-
 `
 
 const Title = styled.h1`
@@ -182,6 +175,7 @@ const Title = styled.h1`
   line-height: 24px;
   letter-spacing: -0.48px;
 `;
+
 const Description = styled.p`
   color: #222;
   font-family: Hyundai Sans Text KR;
@@ -192,3 +186,11 @@ const Description = styled.p`
   letter-spacing: -0.39px;
 `;
 
+const StTabContainer = styled.div`
+  position: absolute;
+  top: 68px;
+  left: 128px;
+  display: inline-flex;
+  align-items: flex-start;
+  gap: 24px;
+`

--- a/frontend/Idle/src/pages/trimPage.jsx
+++ b/frontend/Idle/src/pages/trimPage.jsx
@@ -8,10 +8,12 @@ import { TRIM_ROUTE } from "../utils/routes";
 import { carContext } from "../utils/context";
 import FindTrim from "../components/findTrim/FindTrim";
 
+let cachedTrimData = null;
+
 function TrimPage() {
   const { car } = useContext(carContext);
   const navigate = useNavigate();
-  const [trimData, setTrimData] = useState(null);
+  const [trimData, setTrimData] = useState(cachedTrimData);
 
   function nextBTNClicked() {
     navigate("/detail");
@@ -19,6 +21,7 @@ function TrimPage() {
   useEffect(() => {
     getTrimData().then((result) => {
       setTrimData(result);
+      cachedTrimData = result
     });
   }, []);
 

--- a/frontend/Idle/src/utils/constants.jsx
+++ b/frontend/Idle/src/utils/constants.jsx
@@ -17,6 +17,11 @@ export const DETAIL = "detail";
 export const COLOR = "color";
 export const OPTION = "option";
 export const BILL = "bill";
+export const ENGINES = "engines";
+export const DRVING_METHODS = "driving_methods";
+export const BODY_TYPES = "body_types";
+
+
 
 export let clickedOptionPage = false;
 


### PR DESCRIPTION
## 🚩 관련 이슈
- close #67 

## 📋 구현 기능 명세
- [x] 텍스트와 on/off 상태별 css
- [x] prop으로 텍스트, 온클릭함수
- [x] 데이터 받아서 foreach나 map 으로 상세모델 선택목록 컴포넌트 재사용

## 📌 PR Point
- constant.jsx에 탭의 한글과 영어를 저장함으로써 상수로 사용하였다.
- tabs에 저장한 상수들을 배열로 사용하면서 코드의 반복을 줄였다

## 📸 결과물 스크린샷
<img width="253" alt="스크린샷 2023-08-07 오후 9 49 51" src="https://github.com/softeerbootcamp-2nd/A5-Idle/assets/39405559/067812bb-2f5a-4e8d-91b6-1d63df72b162">
