### PR TITLE
[FE] 옵션 변경시 데이터 변경과 경고 모달

### DIFF
--- a/frontend/Idle/src/components/common/modals/RemoveOptionModal.jsx
+++ b/frontend/Idle/src/components/common/modals/RemoveOptionModal.jsx
@@ -1,0 +1,132 @@
+import { styled } from "styled-components";
+import BlueButton from "../buttons/BlueButton";
+import WhiteButton from "../buttons/WhiteButton";
+import { createPortal } from "react-dom";
+import { useContext } from "react";
+import { carContext } from "../../../utils/context";
+
+/**
+ *
+ * @param {string} param0
+ * @returns
+ */
+
+function RemoveOptionModal({ data, setModalVisible }) {
+  const { car, setCar } = useContext(carContext);
+  function confirmClicked() {
+    let options = car.option.additional;
+    options = options.filter((item) => item.name !== data.name);
+    //option additional인 경우에만 해제
+    setCar((prevCar) => ({
+      ...prevCar,
+      option: {
+        additional: options,
+      },
+    }));
+    setModalVisible(false);
+  }
+
+  return createPortal(
+    <ModalContainer>
+      <ModalBackground onClick={() => setModalVisible(false)} />
+      <StContainer>
+        <StTitle>
+          엔진을 변경하시면 <br /> 선택하신 아래 옵션이 해제돼요.
+        </StTitle>
+
+        <StOptionContainer>
+          <StOptionName>{data.name}</StOptionName>
+          <StOptionPrice>+{data.price.toLocaleString()}원</StOptionPrice>
+        </StOptionContainer>
+
+        <StBtnContainer>
+          <WhiteButton text={"취소"} onClick={() => setModalVisible(false)} />
+          <BlueButton text={"확인"} onClick={() => confirmClicked()} />
+        </StBtnContainer>
+      </StContainer>
+    </ModalContainer>,
+    document.getElementById("modal")
+  );
+}
+
+export default RemoveOptionModal;
+
+const StContainer = styled.div`
+  display: flex;
+  width: 451px;
+  height: 266px;
+  padding: 32px 44px 48px 44px;
+  background: ${({ theme }) => theme.White};
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 1;
+`;
+
+const StTitle = styled.div`
+  width: 100%;
+  font-family: "Hyundai Sans Text KR";
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 145%;
+  letter-spacing: -0.6px;
+  text-align: center;
+  margin-bottom: 32px;
+`;
+
+const StOptionContainer = styled.div`
+  display: flex;
+  width: 168px;
+  height: 68px;
+  padding: 12px 24px;
+  border: 1px solid ${({ theme }) => theme.Grey_2};
+  background: ${({ theme }) => theme.White};
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  margin-bottom: 48px;
+  gap: 24px;
+`;
+const StOptionName = styled.div`
+  font-family: "Hyundai Sans Text KR";
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 24px;
+  letter-spacing: -0.48px;
+`;
+const StOptionPrice = styled.div`
+  font-family: "Hyundai Sans Text KR";
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 20px;
+  letter-spacing: -0.42px;
+`;
+const StBtnContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+`;
+
+const ModalBackground = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(5px);
+`;
+const ModalContainer = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 1280px;
+  height: 720px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;

--- a/frontend/Idle/src/pages/billPage.jsx
+++ b/frontend/Idle/src/pages/billPage.jsx
@@ -1,5 +1,18 @@
+import { useEffect, useState } from "react";
+import RemoveOptionModal from "../components/common/modals/RemoveOptionModal";
+
 function BillPage() {
-  return <div>billPage</div>;
+  const data = {
+    name: "듀얼와이드 선루프",
+    price: 999999999,
+  };
+  const [modalVisible, setModalVisible] = useState(false);
+  useEffect(() => {
+    setModalVisible(true);
+  }, []);
+  return (
+    <>{modalVisible ? <RemoveOptionModal data={data} setModalVisible={setModalVisible} /> : null}</>
+  );
 }
 
 export default BillPage;


### PR DESCRIPTION
## 🚩 관련 이슈
- close #66 

## 📋 구현 기능 명세
- [x] 모달 css
- [x] prop으로 옵션 데이터 받아오기
- [x] 취소, 확인 컴포넌트 재사용
- [x] 취소 온클릭 → 모달 닫기
- [x] 확인 온클릭 → prop을 전역 차 객체에 업데이트 & 모달 닫기

## 📸 결과물 스크린샷
![image](https://github.com/softeerbootcamp-2nd/A5-Idle/assets/108254103/501f2388-a46b-4fd1-b23b-3e73795ec31b)
