### PR TITLE
[FE] 옵션 선택 버튼 ( 고민해보기, 취소하기, 추가하기) 컴포넌트 구현

### DIFF
--- a/frontend/Idle/src/components/common/buttons/AddButton.jsx
+++ b/frontend/Idle/src/components/common/buttons/AddButton.jsx
@@ -1,0 +1,37 @@
+import { styled } from "styled-components"
+
+function AddButton({ state, onClick }) {
+    return (
+        <StContainer onClick={onClick} $state={state} >{state === "add" ? "취소하기" : "추가하기"}</StContainer>
+    )
+}
+
+export default AddButton
+
+const StContainer = styled.div`
+    display: flex;
+    width: 78px;
+    padding: 4px 12px;
+    border: 0.5px solid ${({ $state }) => $state === "none" ? "#222" : "#fff"};
+    color:${({ $state }) => {
+        switch ($state) {
+            case "none":
+                return "#fff"
+            case "confuse":
+                return "#9B6D54"
+            case "add":
+                return "#1A3276"
+        }
+    }};
+    background: ${({ $state }) => $state === "none" ? "#1A3276" : "#fff"};
+    justify-content: center;
+    align-items: center;
+    gap: 11.624px;
+    font-family: "Hyundai Sans Text KR";
+    font-size: 12px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 16px;
+    letter-spacing: -0.36px;
+    text-align: center;
+`

--- a/frontend/Idle/src/components/common/buttons/ConfusingButton.jsx
+++ b/frontend/Idle/src/components/common/buttons/ConfusingButton.jsx
@@ -1,0 +1,27 @@
+import { styled } from "styled-components"
+
+function ConfusingButton({ state, onClick }) {
+    return (
+        <StContainer onClick={onClick} $state={state} >{state === "confuse" ? "추가하기" : "고민해보기"}</StContainer>
+    )
+}
+
+export default ConfusingButton
+
+const StContainer = styled.div`
+    display: flex;
+    width: 78px;
+    padding: 4px 12px;
+    border: 0.5px solid ${({ $state }) => $state === "none" ? "#222" : "#fff"};
+    justify-content: center;
+    align-items: center;
+    gap: 11.624px;
+    color: ${({ $state }) => $state === "none" ? "#222" : "#FFF"};
+    font-family: "Hyundai Sans Text KR";
+    font-size: 12px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 16px;
+    letter-spacing: -0.36px;
+    text-align: center;
+`


### PR DESCRIPTION
## 🚩 관련 이슈
- close #113 

## 📋 구현 기능 명세
- [x] 버튼 css (상태별로 css 변경)
- [x]  prop으로 상태(고민해보기, 일반, 클릭), 온클릭함수

## 📌 PR Point
- 다양한 상태별 구분
- 온클릭 함수와 state("none","confuse","add")를 prop으로 받는다

고민해보기 | 추가하기 | 박스 배경 | 버튼 배경 | 버튼 글씨 | 버튼 테두리색
-- | -- | -- | -- | -- | --
false | false | 흰색 | 투명, 파란색 | 검은색/ 흰색 | 검정색/ 검정색
false | true | 파란색 | 투명, 흰색 | 흰색 / 파란색 | 흰색 / 흰색
true | false | 갈색 | 투명, 흰색 | 흰색 / 갈색 | 흰색 / 흰색

## 📸 결과물 스크린샷
<img width="283" alt="스크린샷 2023-08-09 오후 4 13 10" src="https://github.com/softeerbootcamp-2nd/A5-Idle/assets/39405559/cdcb4224-8219-4564-861f-032f001209c3">
