### PR TITLE
[feat] 최종 견적서 페이지 틀 구현

### DIFF
--- a/frontend/Idle/src/components/common/boxs/DetailModelBox.jsx
+++ b/frontend/Idle/src/components/common/boxs/DetailModelBox.jsx
@@ -48,7 +48,7 @@ function DetailModelBox({ purchase_rate, name, description, price, currentTab, i
             </StContentHeader>
             <Detail $isSelected={isOptionSelected}>{description}</Detail>
           </StTitleContainer>
-          <Price $isSelected={isOptionSelected}>{price.toLocaleString()} 원</Price>
+          <Price $isSelected={isOptionSelected}>+ {price.toLocaleString()} 원</Price>
         </StContent>
       </StContainer>
     </>

--- a/frontend/Idle/src/components/common/content/Car3D.jsx
+++ b/frontend/Idle/src/components/common/content/Car3D.jsx
@@ -95,6 +95,8 @@ const Circle = styled.div`
   border-radius: 50%;
   background-image: linear-gradient(#ffffff, #ffffff),
     linear-gradient(0deg, #14285e 0%, #14285e45 50%, white 100%);
+  /* background-image: linear-gradient(180deg, #DDE4F8 100%, rgba(231, 235, 246, 0.00) 0%),
+    linear-gradient(0deg, #14285e 0%, #14285e45 50%, white 100%); */
   background-origin: border-box;
   background-clip: content-box, border-box;
   z-index: -1;

--- a/frontend/Idle/src/components/common/toolTips/ConfusingTooltip.jsx
+++ b/frontend/Idle/src/components/common/toolTips/ConfusingTooltip.jsx
@@ -1,4 +1,4 @@
-import { ReactComponent as ConfusingTooltipIcon } from "../../assets/images/confusingTooltip.svg";
+import { ReactComponent as ConfusingTooltipIcon } from "../../../assets/images/confusingTooltip.svg";
 import PropTypes from "prop-types";
 
 function ConfusingTooltip({ isActive }) {

--- a/frontend/Idle/src/components/common/toolTips/FindTrimTooltip.jsx
+++ b/frontend/Idle/src/components/common/toolTips/FindTrimTooltip.jsx
@@ -1,4 +1,4 @@
-import { ReactComponent as FindTrimTooltipIcon } from "../../assets/images/findTrimTooltip.svg";
+import { ReactComponent as FindTrimTooltipIcon } from "../../../assets/images/findTrimTooltip.svg";
 import PropTypes from "prop-types";
 
 function FindTrimTooltip({ isActive }) {

--- a/frontend/Idle/src/components/common/toolTips/OptionTooltip.jsx
+++ b/frontend/Idle/src/components/common/toolTips/OptionTooltip.jsx
@@ -1,4 +1,4 @@
-import { ReactComponent as OptionTooltipIcon } from "../../assets/images/optionTooltip.svg";
+import { ReactComponent as OptionTooltipIcon } from "../../../assets/images/optionTooltip.svg";
 import PropTypes from "prop-types";
 
 function OptionTooltip({ isActive }) {

--- a/frontend/Idle/src/pages/billPage.jsx
+++ b/frontend/Idle/src/pages/billPage.jsx
@@ -1,5 +1,72 @@
+import { styled } from "styled-components";
+import Header from "../components/layout/Header";
+
 function BillPage() {
-  return <></>;
+  return (
+    <StWrapper id={"modal"}>
+      <StContainer >
+        <Header />
+        <TitleContainer>
+          <StTitle>팰리세이드와 함께 <br />드라이브 떠나볼까요?</StTitle>
+          카마스터 찾기를 통해 구매 상담을 할 수 있어요
+        </TitleContainer>
+        <BlueBG />
+        <BlueBgBottom />
+      </StContainer >
+    </StWrapper >
+  );
 }
 
 export default BillPage;
+
+
+const StWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+const StContainer = styled.div`
+  position: relative;
+  width: 1280px;
+  height: 720px;
+  overflow: scroll;
+`;
+const BlueBG = styled.div`
+  width: 1280px;
+  height: 641px;
+  background: linear-gradient(180deg, #DDE4F8 0%, rgba(231, 235, 246, 0.00) 100%);
+`
+const BlueBgBottom = styled(BlueBG)`
+  position: absolute;
+  height: 267px;
+  top: 414px; 
+  z-index: -2;
+`
+const TitleContainer = styled.div`
+  position: absolute;
+  top: 88px;
+  left: 148px;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  p{
+    color:#222;
+    font-family: "Hyundai Sans Text KR";
+    font-size: 16px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 24px;
+    letter-spacing: -0.48px;
+  }
+`
+const StTitle = styled.h1`
+  color:#222;
+  width: 261px;
+  font-family: "Hyundai Sans Head KR";
+  font-size: 32px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 40px;
+  letter-spacing: -0.96px;
+`

--- a/frontend/Idle/src/pages/billPage.jsx
+++ b/frontend/Idle/src/pages/billPage.jsx
@@ -3,8 +3,12 @@ import Header from "../components/layout/Header";
 import Car3D from "../components/common/content/Car3D";
 import WhiteButton from "../components/common/buttons/WhiteButton";
 import BlueButton from "../components/common/buttons/BlueButton";
+import { useContext } from "react";
+import { carContext } from "../utils/context";
 
 function BillPage() {
+  const { car } = useContext(carContext)
+
   return (
     <StWrapper id={"modal"}>
       <StContainer >
@@ -21,7 +25,7 @@ function BillPage() {
         <StConfirmContainer>
           <StConfirmText>
             <p>예상 가격</p>
-            <h1>38,960,000 원</h1>
+            <h1>{car.getAllSum().toLocaleString()} 원</h1>
           </StConfirmText>
           <StButtonContainer>
             <WhiteButton text={"공유하기"} />
@@ -87,26 +91,26 @@ const StTitle = styled.h1`
   letter-spacing: -0.96px;
 `
 const CarContainer = styled.div`
-    position: absolute;
-    width: 573px;
-    height: 359px;
-    flex-shrink: 0;
-    top: 100px;
-    left: 50px;
+  position: absolute;
+  width: 573px;
+  height: 359px;
+  flex-shrink: 0;
+  top: 100px;
+  left: 50px;
 `
 const StConfirmContainer = styled.div`
   display: flex;
   flex-direction: row;
-  gap:40px
+  gap:40px;
 `
 const StConfirmText = styled.div`
   position: absolute;
-    display: flex;
-    flex-direction: column;
-    color: #222;
-    bottom: 30px;
-    gap: 8px;
-    right: 322px;
+  display: flex;
+  flex-direction: column;
+  color: #222;
+  top: 580px;
+  gap: 8px;
+  right: 320px;
   p{
     font-family: "Hyundai Sans Text KR";
     font-size: 16px;
@@ -115,6 +119,7 @@ const StConfirmText = styled.div`
     line-height: 24px;
     letter-spacing: -0.48px;
     text-align: right;
+    margin-top: 5px;
   }
   h1{
     font-family: "Hyundai Sans Head KR";
@@ -125,10 +130,10 @@ const StConfirmText = styled.div`
   }
 `
 const StButtonContainer = styled.div`
-  position: fixed;
+  position: absolute;
   display: flex;
   flex-direction: column;
   gap: 4px;
-  right: 128px;
-  bottom: 25px;
+  left: 998px;
+  top: 580px;
 `

--- a/frontend/Idle/src/pages/billPage.jsx
+++ b/frontend/Idle/src/pages/billPage.jsx
@@ -1,5 +1,8 @@
 import { styled } from "styled-components";
 import Header from "../components/layout/Header";
+import Car3D from "../components/common/content/Car3D";
+import WhiteButton from "../components/common/buttons/WhiteButton";
+import BlueButton from "../components/common/buttons/BlueButton";
 
 function BillPage() {
   return (
@@ -11,7 +14,20 @@ function BillPage() {
           카마스터 찾기를 통해 구매 상담을 할 수 있어요
         </TitleContainer>
         <BlueBG />
+        <CarContainer>
+          <Car3D />
+        </CarContainer>
         <BlueBgBottom />
+        <StConfirmContainer>
+          <StConfirmText>
+            <p>예상 가격</p>
+            <h1>38,960,000 원</h1>
+          </StConfirmText>
+          <StButtonContainer>
+            <WhiteButton text={"공유하기"} />
+            <BlueButton text={"카마스터 찾기"} />
+          </StButtonContainer>
+        </StConfirmContainer>
       </StContainer >
     </StWrapper >
   );
@@ -69,4 +85,50 @@ const StTitle = styled.h1`
   font-weight: 500;
   line-height: 40px;
   letter-spacing: -0.96px;
+`
+const CarContainer = styled.div`
+    position: absolute;
+    width: 573px;
+    height: 359px;
+    flex-shrink: 0;
+    top: 100px;
+    left: 50px;
+`
+const StConfirmContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap:40px
+`
+const StConfirmText = styled.div`
+  position: absolute;
+    display: flex;
+    flex-direction: column;
+    color: #222;
+    bottom: 30px;
+    gap: 8px;
+    right: 322px;
+  p{
+    font-family: "Hyundai Sans Text KR";
+    font-size: 16px;
+    font-style: normal;
+    font-weight: 700;
+    line-height: 24px;
+    letter-spacing: -0.48px;
+    text-align: right;
+  }
+  h1{
+    font-family: "Hyundai Sans Head KR";
+    font-size: 28px;
+    font-weight: 500;
+    line-height: 36px;
+    letter-spacing: -0.84px;
+  }
+`
+const StButtonContainer = styled.div`
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  right: 128px;
+  bottom: 25px;
 `

--- a/frontend/Idle/src/utils/router.jsx
+++ b/frontend/Idle/src/utils/router.jsx
@@ -15,8 +15,8 @@ function Router() {
         <Route path="/detail" element={<DetailModelPage />} />
         <Route path="/color" element={<ColorPage />} />
         <Route path="/option" element={<OptionPage />} />
-        <Route path="/bill" element={<BillPage />} />
       </Route>
+      <Route path="/bill" element={<BillPage />} />
       <Route path="/" element={<MainPage />} />
     </Routes>
   );


### PR DESCRIPTION
## 🚩 관련 이슈
- close #126 

## 📋 구현 기능 명세
- [x] 견적서 상단 부분 css
- [x] 전역 객체에 저장되어있는 차 색상에 따라 이미지 ( 360 ) 렌더링
## 📌 PR Point
- 자동차 360도 아래 원의 배경은 추후에 prop으로 처리할 예정

## 📸 결과물 스크린샷
<img width="1267" alt="스크린샷 2023-08-10 오후 7 41 10" src="https://github.com/softeerbootcamp-2nd/A5-Idle/assets/39405559/ac7b8a91-92d4-47bc-838c-23cd5ca7b192">
