### PR TITLE
[FE] 견적서 완성 기본 견적

### DIFF
--- a/frontend/Idle/src/components/BillMain/BillDetail.jsx
+++ b/frontend/Idle/src/components/BillMain/BillDetail.jsx
@@ -2,6 +2,7 @@ import { styled } from "styled-components"
 import { TRANSLATE } from "../../utils/constants"
 import { useContext } from "react"
 import { carContext } from "../../utils/context"
+import ModifyButton from "../common/buttons/ModifyButton"
 
 function BillDetail({ item }) {
     const { car } = useContext(carContext)
@@ -37,7 +38,8 @@ function BillDetail({ item }) {
     return (
         <StContainer>
             <StTitle>
-                {TRANSLATE[item]}
+                <h1>{TRANSLATE[item]}</h1>
+                <ModifyButton />
             </StTitle>
             <StDetailContainer>
                 <h1>{detail ? detail : "아직 선택하지 않았습니다."}</h1>

--- a/frontend/Idle/src/components/BillMain/BillDetail.jsx
+++ b/frontend/Idle/src/components/BillMain/BillDetail.jsx
@@ -43,7 +43,7 @@ function BillDetail({ item }) {
             </StTitle>
             <StDetailContainer>
                 <h1>{detail ? detail : "아직 선택하지 않았습니다."}</h1>
-                <p>{price ? price.toLocaleString() : ""}</p>
+                <p>{price ? price.toLocaleString() : "0"} 원</p>
             </StDetailContainer>
         </StContainer>
     )

--- a/frontend/Idle/src/components/BillMain/BillDetail.jsx
+++ b/frontend/Idle/src/components/BillMain/BillDetail.jsx
@@ -1,0 +1,98 @@
+import { styled } from "styled-components"
+import { TRANSLATE } from "../../utils/constants"
+import { useContext } from "react"
+import { carContext } from "../../utils/context"
+
+function BillDetail({ item }) {
+    const { car } = useContext(carContext)
+    let detail, price
+    switch (item) {
+        case "trim":
+            detail = car.trim.name
+            price = car.getTrimSum()
+            break;
+        case "engines":
+            detail = car.detail.engines.name
+            price = car.detail.engines.price
+            break;
+        case "driving_methods":
+            detail = car.detail.driving_methods.name
+            price = car.detail.driving_methods.price
+            break;
+        case "body_types":
+            detail = car.detail.body_types.name
+            price = car.detail.body_types.price
+            break;
+        case "exterior_colors":
+            detail = car.color.outside.name
+            price = car.color.outside.price
+            break;
+        case "interior_colors":
+            detail = car.color.inside.name
+            price = car.color.inside.price
+            break;
+        default:
+            break;
+    }
+    return (
+        <StContainer>
+            <StTitle>
+                {TRANSLATE[item]}
+            </StTitle>
+            <StDetailContainer>
+                <h1>{detail ? detail : "아직 선택하지 않았습니다."}</h1>
+                <p>{price ? price.toLocaleString() : ""}</p>
+            </StDetailContainer>
+        </StContainer>
+    )
+}
+
+export default BillDetail
+
+const StContainer = styled.div`
+    display: flex;
+    align-items: flex-start;
+    gap: 67px;
+`
+const StTitle = styled.div`
+    display: flex;
+    width: 87px;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+    h1{
+        color: #222;
+        font-family: "Hyundai Sans Head KR";
+        font-size: 24px;
+        font-style: normal;
+        font-weight: 500;
+        line-height: 32px;
+        letter-spacing: -0.72px;
+    }
+`
+const StDetailContainer = styled.div`
+    display: flex;
+    flex-direction: row;
+    width: 676px;
+    height: 31px;
+    justify-content: space-between;
+    flex-shrink: 0;
+    h1{
+        color: var(--black, #222);
+        font-family: "Hyundai Sans Text KR";
+        font-size: 22px;
+        font-style: normal;
+        font-weight: 500;
+        line-height: 28px;
+        letter-spacing: -0.66px;
+    }
+    p{
+        color: var(--black, #222);
+        font-family: "Hyundai Sans Text KR";
+        font-size: 22px;
+        font-style: normal;
+        font-weight: 700;
+        line-height: 28px;
+        letter-spacing: -0.66px;
+    }
+`

--- a/frontend/Idle/src/components/BillMain/BillMain.jsx
+++ b/frontend/Idle/src/components/BillMain/BillMain.jsx
@@ -10,9 +10,11 @@ function BillMain() {
         </>)
     }
     return (
-        <StContainer>{
-            BILL_LIST.map((item) => render(item))
-        }</StContainer>
+        <StContainer>
+            <StTitle>기본 견적</StTitle>
+            {
+                BILL_LIST.map((item) => render(item))
+            }</StContainer>
     )
 }
 
@@ -22,13 +24,22 @@ const StContainer = styled.div`
     display: flex;
     width: 831px;
     flex-direction: column;
-    align-items: center;
     justify-content: center;
     margin-right: 120px;
     gap: 32px;
+    margin-top: 50px;
 `
 const Division = styled.div`
     background-color: #7B7B7B;
     width: 830px;
     height: 1px;
+`
+const StTitle = styled.h1`
+    color: #222;
+    font-family: "Hyundai Sans Text KR";
+    font-size: 28px;
+    font-style: normal;
+    font-weight: 700;
+    line-height: 28px;
+    letter-spacing: -1.08px;
 `

--- a/frontend/Idle/src/components/BillMain/BillMain.jsx
+++ b/frontend/Idle/src/components/BillMain/BillMain.jsx
@@ -1,0 +1,34 @@
+import { styled } from "styled-components"
+import BillDetail from "./BillDetail"
+import { BILL_LIST } from "../../utils/constants"
+
+function BillMain() {
+    function render(item) {
+        return (<>
+            <BillDetail item={item} />
+            <Division />
+        </>)
+    }
+    return (
+        <StContainer>{
+            BILL_LIST.map((item) => render(item))
+        }</StContainer>
+    )
+}
+
+export default BillMain
+
+const StContainer = styled.div`
+    display: flex;
+    width: 831px;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    margin-right: 120px;
+    gap: 32px;
+`
+const Division = styled.div`
+    background-color: #7B7B7B;
+    width: 830px;
+    height: 1px;
+`

--- a/frontend/Idle/src/components/common/buttons/ModifyButton.jsx
+++ b/frontend/Idle/src/components/common/buttons/ModifyButton.jsx
@@ -1,0 +1,32 @@
+import { styled } from "styled-components";
+import { ReactComponent as ArrowRight } from "../../../assets/images/arrowRight.svg";
+
+function ModifyButton() {
+    return (
+        <StContainer>
+            <StTitle>변경하기</StTitle>
+            <ArrowRight />
+        </StContainer>
+    )
+}
+
+export default ModifyButton
+
+const StContainer = styled.div`
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    gap: 8px;
+`
+
+const StTitle = styled.p`
+    color: #81899E;
+    font-family: "Hyundai Sans Text KR";
+    font-size: 16px;
+    font-style: normal;
+    font-weight: 300;
+    line-height: 24px;
+    letter-spacing: -0.48px;
+    text-align: center;
+`

--- a/frontend/Idle/src/pages/billPage.jsx
+++ b/frontend/Idle/src/pages/billPage.jsx
@@ -5,6 +5,7 @@ import WhiteButton from "../components/common/buttons/WhiteButton";
 import BlueButton from "../components/common/buttons/BlueButton";
 import { useContext } from "react";
 import { carContext } from "../utils/context";
+import BillMain from "../components/BillMain/BillMain";
 
 function BillPage() {
   const { car } = useContext(carContext)
@@ -32,13 +33,13 @@ function BillPage() {
             <BlueButton text={"카마스터 찾기"} />
           </StButtonContainer>
         </StConfirmContainer>
+        <BillMain />
       </StContainer >
     </StWrapper >
   );
 }
 
 export default BillPage;
-
 
 const StWrapper = styled.div`
   display: flex;
@@ -47,9 +48,13 @@ const StWrapper = styled.div`
 `;
 const StContainer = styled.div`
   position: relative;
-  width: 1280px;
-  height: 720px;
-  overflow: scroll;
+  position: relative;
+    display: flex;
+    flex-direction: column;
+    width: 1280px;
+    overflow: scroll;
+    justify-content: center;
+    align-items: center;
 `;
 const BlueBG = styled.div`
   width: 1280px;

--- a/frontend/Idle/src/utils/constants.jsx
+++ b/frontend/Idle/src/utils/constants.jsx
@@ -7,12 +7,16 @@ export const TYPE = {
   bill: "견적서 완성",
 };
 
+export const BILL_LIST = ["trim", "engines", "driving_methods", "body_types", "exterior_colors", "interior_colors", "option"]
+
 export const TRANSLATE = {
+  trim: "트림",
   engines: "엔진",
   driving_methods: "구동방식",
   body_types: "바디타입",
   exterior_colors: "외장 색상",
   interior_colors: "내장 색상",
+  option: "옵션",
   all: "전체",
   safety: "안전",
   style: "스타일&퍼포먼스",


### PR DESCRIPTION
## 🚩 관련 이슈
- close #123 

## 📋 구현 기능 명세
- [x]  컨테이너 생성
- [x]  변경하기 버튼
- [x]  차 객체에서 데이터 읽어와 컨테이너 별로 넘겨주기

## 📌 PR Point
- 공용컴포넌트를 타입에 따라 switch문으로 구분해주었는데 더 좋은 방법으로 바꾸고 싶다.
- 변경하기를 누르면 해당 페이지로 이동하는 navigate로 가려했으나, 우리는 detail에서 useState로 탭을 관리하는데 이를 어떻게 해야할 지 상의해보아야 한다.

## 📸 결과물 스크린샷
<img width="1075" alt="스크린샷 2023-08-10 오후 11 03 09" src="https://github.com/softeerbootcamp-2nd/A5-Idle/assets/39405559/a106438b-68d4-492f-93fd-24d49c352e69">
