### PR TITLE
[BE] 추가 옵션 선택 페이지 호출 API 구현

### DIFF
--- a/backend/src/main/java/com/autoever/idle/domain/function/FunctionRepository.java
+++ b/backend/src/main/java/com/autoever/idle/domain/function/FunctionRepository.java
@@ -1,6 +1,7 @@
 package com.autoever.idle.domain.function;
 
 import com.autoever.idle.domain.function.dto.AdditionalFunctionBillDto;
+import com.autoever.idle.domain.function.dto.FunctionDto;
 import com.autoever.idle.domain.function.dto.MyTrimFunctionDto;
 import com.autoever.idle.domain.myTrim.dto.MyTrimDto;
 import com.autoever.idle.domain.option.MyTrimOptionDto;
@@ -15,4 +16,5 @@ public interface FunctionRepository {
     List<MyTrimDto> findTrimBySelectFunctions(int functionId);
     String checkMyTrimFunction(int functionId);
     MyTrimOptionDto findOptionBySelectFunction(Long functionId);
+    List<FunctionDto> findFunctionsInAdditionalOption(Long optionId);
 }

--- a/backend/src/main/java/com/autoever/idle/domain/function/FunctionRepositoryImpl.java
+++ b/backend/src/main/java/com/autoever/idle/domain/function/FunctionRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.autoever.idle.domain.function;
 
 import com.autoever.idle.domain.function.dto.AdditionalFunctionBillDto;
+import com.autoever.idle.domain.function.dto.FunctionDto;
 import com.autoever.idle.domain.function.dto.MyTrimFunctionDto;
 import com.autoever.idle.domain.myTrim.dto.MyTrimDto;
 import com.autoever.idle.domain.option.MyTrimOptionDto;
@@ -79,5 +80,16 @@ public class FunctionRepositoryImpl implements FunctionRepository {
                         "JOIN `OPTION` AS O ON F.option_id=O.option_id " +
                         "WHERE function_id=?",
                 rowMapper, functionId);
+    }
+
+    @Override
+    public List<FunctionDto> findFunctionsInAdditionalOption(Long optionId) {
+        String query = "select f.function_id functionId, f.name functionName, f.description functionDescription, " +
+                "f.img_url functionImgUrl, f.wheel_logo_img_url wheelLoglImgUrl " +
+                "from FUNCTIONS f left join `OPTION` o on f.option_id = o.option_id " +
+                "where f.option_id = ? and REPLACE(f.name, ' ', '') != REPLACE(o.name, ' ', '')";
+
+        RowMapper rowMapper = new BeanPropertyRowMapper(FunctionDto.class);
+        return jdbcTemplate.query(query, rowMapper, optionId);
     }
 }

--- a/backend/src/main/java/com/autoever/idle/domain/function/dto/FunctionDto.java
+++ b/backend/src/main/java/com/autoever/idle/domain/function/dto/FunctionDto.java
@@ -1,0 +1,25 @@
+package com.autoever.idle.domain.function.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FunctionDto {
+    private Long functionId;
+    private String functionName;
+    private String functionDescription;
+    private String functionImgUrl;
+    private String wheelLogoImgUrl;
+
+    public FunctionDto(Long functionId, String functionName, String functionDescription, String functionImgUrl, String wheelLogoImgUrl) {
+        this.functionId = functionId;
+        this.functionName = functionName;
+        this.functionDescription = functionDescription;
+        this.functionImgUrl = functionImgUrl;
+        this.wheelLogoImgUrl = wheelLogoImgUrl;
+    }
+}

--- a/backend/src/main/java/com/autoever/idle/domain/option/OptionController.java
+++ b/backend/src/main/java/com/autoever/idle/domain/option/OptionController.java
@@ -1,0 +1,28 @@
+package com.autoever.idle.domain.option;
+
+import com.autoever.idle.domain.option.dto.OptionFunctionsDto;
+import com.autoever.idle.domain.option.dto.OptionRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/trims/add")
+@RequiredArgsConstructor
+public class OptionController {
+
+    private final OptionService optionService;
+
+    @PostMapping("/options")
+    public ResponseEntity<List<OptionFunctionsDto>> getOptionFunctions(@RequestBody OptionRequest optionRequest) {
+        List<OptionFunctionsDto> optionFunctions = optionService.getOptionFunctions(optionRequest);
+        return ResponseEntity.ok(optionFunctions);
+    }
+
+
+}

--- a/backend/src/main/java/com/autoever/idle/domain/option/OptionRepository.java
+++ b/backend/src/main/java/com/autoever/idle/domain/option/OptionRepository.java
@@ -1,0 +1,12 @@
+package com.autoever.idle.domain.option;
+
+import com.autoever.idle.domain.option.dto.OptionDto;
+
+import java.util.List;
+
+
+public interface OptionRepository {
+    List<OptionDto> findAdditionalOptionList(Long trimId);
+
+    List<Long> findNotActivatedOptionIdList(Long engineId, List<Long> selectedOptionIdList);
+}

--- a/backend/src/main/java/com/autoever/idle/domain/option/OptionRepositoryImpl.java
+++ b/backend/src/main/java/com/autoever/idle/domain/option/OptionRepositoryImpl.java
@@ -1,0 +1,53 @@
+package com.autoever.idle.domain.option;
+
+import com.autoever.idle.domain.option.dto.OptionDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.SingleColumnRowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class OptionRepositoryImpl implements OptionRepository{
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    @Override
+    public List<OptionDto> findAdditionalOptionList(Long trimId) {
+        String query = "select o.option_id optionId, o.name optionName, o.price optionPrice, o.purchase_rate optionPurchaseRate,\n" +
+                "o.description optionDescription, oc.name optionCategory " +
+                "from FUNCTIONS f join TRIM_FUNCTION tf on f.function_id = tf.function_id " +
+                "join `OPTION` o on f.option_id = o.option_id " +
+                "join OPTION_CATEGORY oc on o.option_category_id = oc.option_category_id " +
+                "where tf.trim_id = 1 and tf.is_default = 'false' " +
+                "group by optionId " +
+                "order by optionPrice";
+
+        MapSqlParameterSource params = new MapSqlParameterSource();
+        params.addValue("trimId", trimId);
+
+        RowMapper rowMapper = new BeanPropertyRowMapper(OptionDto.class);
+        return jdbcTemplate.query(query, params, rowMapper);
+    }
+
+    @Override
+    public List<Long> findNotActivatedOptionIdList(Long engineId, List<Long> selectedOptionIdList) {
+        String query = "SELECT os.not_activated_option_id FROM OPTION_STATUS os " +
+                "WHERE os.selected_engine_id = :engineId OR os.selected_option_id IN (:selectedOptionIdList)";
+
+        MapSqlParameterSource params = new MapSqlParameterSource();
+        params.addValue("engineId", engineId);
+        params.addValue("selectedOptionIdList", selectedOptionIdList);
+
+        RowMapper<Long> rowMapper = new SingleColumnRowMapper<>(Long.class);
+
+        return jdbcTemplate.query(query, params, rowMapper);
+    }
+}

--- a/backend/src/main/java/com/autoever/idle/domain/option/OptionRepositoryImpl.java
+++ b/backend/src/main/java/com/autoever/idle/domain/option/OptionRepositoryImpl.java
@@ -2,9 +2,7 @@ package com.autoever.idle.domain.option;
 
 import com.autoever.idle.domain.option.dto.OptionDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Bean;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.SingleColumnRowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -26,7 +24,7 @@ public class OptionRepositoryImpl implements OptionRepository{
                 "from FUNCTIONS f join TRIM_FUNCTION tf on f.function_id = tf.function_id " +
                 "join `OPTION` o on f.option_id = o.option_id " +
                 "join OPTION_CATEGORY oc on o.option_category_id = oc.option_category_id " +
-                "where tf.trim_id = 1 and tf.is_default = 'false' " +
+                "where tf.trim_id = :trimId and tf.is_default = 'false' " +
                 "group by optionId " +
                 "order by optionPrice";
 

--- a/backend/src/main/java/com/autoever/idle/domain/option/OptionService.java
+++ b/backend/src/main/java/com/autoever/idle/domain/option/OptionService.java
@@ -1,0 +1,75 @@
+package com.autoever.idle.domain.option;
+
+import com.autoever.idle.domain.exteriorColor.dto.ExteriorColorDto;
+import com.autoever.idle.domain.function.FunctionRepository;
+import com.autoever.idle.domain.option.dto.OptionDto;
+import com.autoever.idle.domain.option.dto.OptionFunctionsDto;
+import com.autoever.idle.domain.option.dto.OptionRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OptionService {
+
+    private final OptionRepository optionRepository;
+    private final FunctionRepository functionRepository;
+
+    public List<OptionFunctionsDto> getOptionFunctions(OptionRequest optionRequest) {
+        /*TODO
+           1. 해당 트림에 대한 추가 옵션 목록을 불러온다.
+           2. 그 중 선택된 옵션들을 통해 활성화하면 안되는 옵션을 파악한다.
+           3.전체 옵션에 포함된 기능들의 목록을 꺼낸다
+        */
+
+        List<OptionDto> additionalOptionList = optionRepository.findAdditionalOptionList(optionRequest.getTrimId());
+        List<Long> notActivatedOptionIdList = optionRepository.findNotActivatedOptionIdList(optionRequest.getEngineId(), optionRequest.getSelectedOptionIds());
+        List<OptionFunctionsDto> optionFunctionsDtoList = new ArrayList<>();
+
+        for (OptionDto optionDto : additionalOptionList) {
+            if (notActivatedOptionIdList.contains(optionDto.getOptionId())) {
+                optionDto.setOptionCanSelect("false");
+            }
+
+            optionFunctionsDtoList.add(OptionFunctionsDto.create(
+                    optionDto,
+                    functionRepository.findFunctionsInAdditionalOption(optionDto.getOptionId())
+                    )
+            );
+
+        }
+
+        sortByPurchaseRateAndName(optionFunctionsDtoList);
+        return optionFunctionsDtoList;
+    }
+
+    private void sortByPurchaseRateAndName(List<OptionFunctionsDto> optionFunctions) {
+        optionFunctions.sort((o1, o2) -> {
+            if (o1.getOptionPrice() == o2.getOptionPrice()) {
+                if (o1.getOptionPurchaseRate().equals("NEW")) {
+                    return -1;
+                } else if (o2.getOptionPurchaseRate().equals("NEW")) {
+                    return 1;
+                }
+
+                double rate1 = Double.parseDouble(o1.getOptionPurchaseRate().split("%")[0].split(" ")[1]);
+                double rate2 = Double.parseDouble(o2.getOptionPurchaseRate().split("%")[0].split(" ")[1]);
+
+                if (rate1 == rate2) {
+                    return o2.getOptionName().compareTo(o1.getOptionName());
+                } else if (rate1 < rate2) {
+                    return 1;
+                } else {
+                    return -1;
+                }
+            } else if (o1.getOptionPrice() < o2.getOptionPrice()) {
+                return -1;
+            } else {
+                return 1;
+            }
+        });
+    }
+}

--- a/backend/src/main/java/com/autoever/idle/domain/option/OptionService.java
+++ b/backend/src/main/java/com/autoever/idle/domain/option/OptionService.java
@@ -1,6 +1,5 @@
 package com.autoever.idle.domain.option;
 
-import com.autoever.idle.domain.exteriorColor.dto.ExteriorColorDto;
 import com.autoever.idle.domain.function.FunctionRepository;
 import com.autoever.idle.domain.option.dto.OptionDto;
 import com.autoever.idle.domain.option.dto.OptionFunctionsDto;

--- a/backend/src/main/java/com/autoever/idle/domain/option/dto/OptionDto.java
+++ b/backend/src/main/java/com/autoever/idle/domain/option/dto/OptionDto.java
@@ -1,0 +1,29 @@
+package com.autoever.idle.domain.option.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OptionDto {
+    private Long optionId;
+    private String optionName;
+    private Long optionPrice;
+    private String optionPurchaseRate;
+    private String optionDescription;
+    private String optionCategory;
+    private String optionCanSelect = "true";
+
+    public OptionDto(Long optionId, String optionName, Long optionPrice, String optionPurchaseRate, String optionDescription, String optionCategory, String optionCanSelect) {
+        this.optionId = optionId;
+        this.optionName = optionName;
+        this.optionPrice = optionPrice;
+        this.optionPurchaseRate = optionPurchaseRate;
+        this.optionDescription = optionDescription;
+        this.optionCategory = optionCategory;
+        this.optionCanSelect = optionCanSelect;
+    }
+}

--- a/backend/src/main/java/com/autoever/idle/domain/option/dto/OptionFunctionsDto.java
+++ b/backend/src/main/java/com/autoever/idle/domain/option/dto/OptionFunctionsDto.java
@@ -1,0 +1,49 @@
+package com.autoever.idle.domain.option.dto;
+
+import com.autoever.idle.domain.function.dto.FunctionDto;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OptionFunctionsDto {
+    private Long optionId;
+    private String optionName;
+    private Long optionPrice;
+    private String optionPurchaseRate;
+    private String optionDescription;
+    private String optionCategory;
+    private String optionCanSelect = "true";
+    private List<FunctionDto> functions;
+
+    public OptionFunctionsDto(Long optionId, String optionName, Long optionPrice,
+                              String optionPurchaseRate, String optionDescription,
+                              String optionCategory, String optionCanSelect, List<FunctionDto> functions) {
+        this.optionId = optionId;
+        this.optionName = optionName;
+        this.optionPrice = optionPrice;
+        this.optionPurchaseRate = optionPurchaseRate;
+        this.optionDescription = optionDescription;
+        this.optionCategory = optionCategory;
+        this.optionCanSelect = optionCanSelect;
+        this.functions = functions;
+    }
+
+    public static OptionFunctionsDto create(OptionDto optionDto, List<FunctionDto> functions) {
+        return new OptionFunctionsDto(
+                optionDto.getOptionId(),
+                optionDto.getOptionName(),
+                optionDto.getOptionPrice(),
+                optionDto.getOptionPurchaseRate(),
+                optionDto.getOptionDescription(),
+                optionDto.getOptionCategory(),
+                optionDto.getOptionCanSelect(),
+                functions
+        );
+    }
+}

--- a/backend/src/main/java/com/autoever/idle/domain/option/dto/OptionRequest.java
+++ b/backend/src/main/java/com/autoever/idle/domain/option/dto/OptionRequest.java
@@ -1,0 +1,21 @@
+package com.autoever.idle.domain.option.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OptionRequest {
+    private Long trimId;
+    private List<Long> selectedOptionIds;
+    private Long engineId;
+
+    public OptionRequest(Long trimId, List<Long> selectedOptionIds, Long engineId) {
+        this.trimId = trimId;
+        this.selectedOptionIds = selectedOptionIds;
+        this.engineId = engineId;
+    }
+}

--- a/backend/src/test/java/com/autoever/idle/domain/function/FunctionRepositoryImplTest.java
+++ b/backend/src/test/java/com/autoever/idle/domain/function/FunctionRepositoryImplTest.java
@@ -1,6 +1,7 @@
 package com.autoever.idle.domain.function;
 
 import com.autoever.idle.domain.function.dto.AdditionalFunctionBillDto;
+import com.autoever.idle.domain.function.dto.FunctionDto;
 import com.autoever.idle.domain.function.dto.MyTrimFunctionDto;
 import com.autoever.idle.domain.myTrim.dto.MyTrimDto;
 import com.autoever.idle.domain.option.MyTrimOptionDto;
@@ -80,6 +81,21 @@ class FunctionRepositoryImplTest {
 
         softly.assertThat(optionBySelectFunction.getOptionName()).isEqualTo("주차보조 시스템 I");
 
+    }
+
+    @Test
+    @DisplayName("추가 옵션이 포함하는 기능 목록을 반환한다")
+    void findFunctionsInAdditionalOption() {
+        //given
+        Long optionId = 8L;
+
+        //when
+        List<FunctionDto> functions = functionRepository.findFunctionsInAdditionalOption(optionId);
+
+        //then
+        softly.assertThat(functions.size()).isEqualTo(2);
+        softly.assertThat(functions.get(0).getFunctionName()).isEqualTo("러기지 프로텍션 매트");
+        softly.assertThat(functions.get(1).getFunctionName()).isEqualTo("플로어매트 1,2열");
     }
 
 }

--- a/backend/src/test/java/com/autoever/idle/domain/option/OptionControllerTest.java
+++ b/backend/src/test/java/com/autoever/idle/domain/option/OptionControllerTest.java
@@ -1,0 +1,91 @@
+package com.autoever.idle.domain.option;
+
+import com.autoever.idle.domain.function.dto.FunctionDto;
+import com.autoever.idle.domain.option.dto.OptionFunctionsDto;
+import com.autoever.idle.domain.option.dto.OptionRequest;
+import com.autoever.idle.global.exception.GlobalExceptionHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Option Controller Test")
+class OptionControllerTest {
+
+    @Mock
+    private OptionService optionService;
+    @InjectMocks
+    private OptionController optionController;
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper = new ObjectMapper();
+    private List<OptionFunctionsDto> optionFunctionsDtoList = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(optionController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+
+        List<FunctionDto> functionDtoList = new ArrayList<>();
+        functionDtoList.add(new FunctionDto(
+                119L,
+                "러기지 프로텍션 매트",
+                "-",
+                "https://a5idle.s3.ap-northeast-2.amazonaws.com/mycarimages/112-1.jpg",
+                null));
+
+
+        OptionFunctionsDto optionFunctionsDto = new OptionFunctionsDto(
+                8L,
+                "프로텍션 매트 패키지 I",
+                250000L,
+                "구매자 10%가 선택",
+                "흠집없이 내 차에 짐을 싣고 싶다면?\n프로텍션 매트 패기지1로 흠집 걱정 없이 짐을 실어보세요.",
+                "차량 보호",
+                "false",
+                functionDtoList
+        );
+        optionFunctionsDtoList.add(optionFunctionsDto);
+    }
+
+    @Test
+    @DisplayName("추가 옵션 선택 페이지 API를 정상적으로 호출한다")
+    void getOptionFunctions() throws Exception {
+        //given
+        OptionRequest optionRequest = new OptionRequest(1L, List.of(1L, 15L), 1L);
+        given(optionService.getOptionFunctions(any())).willReturn(optionFunctionsDtoList);
+
+        //when
+        ResultActions resultActions = mockMvc.perform(post("/trims/add/options")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(optionRequest)))
+                .andDo(print());
+
+        //then
+        resultActions.andExpect(status().isOk());
+        resultActions.andExpect(content().contentType(MediaType.APPLICATION_JSON));
+        resultActions.andExpect(content().json(objectMapper.writeValueAsString(optionFunctionsDtoList)));
+    }
+
+
+}

--- a/backend/src/test/java/com/autoever/idle/domain/option/OptionRepositoryImplTest.java
+++ b/backend/src/test/java/com/autoever/idle/domain/option/OptionRepositoryImplTest.java
@@ -1,0 +1,55 @@
+package com.autoever.idle.domain.option;
+
+import com.autoever.idle.domain.option.dto.OptionDto;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+@ExtendWith(SoftAssertionsExtension.class)
+@DisplayName("Option Repository Test")
+@SpringBootTest
+class OptionRepositoryImplTest {
+
+    @InjectSoftAssertions
+    private SoftAssertions softAssertions;
+
+    @Autowired
+    private OptionRepository optionRepository;
+
+//    @Test
+//    @DisplayName("트림 ID에 대한 추가 옵션 정보를 담은 목록을 반환한다")
+//    void findAdditionalOptionList() {
+//        //given
+//        Long trimId = 1L;
+//
+//        //when
+//        List<OptionDto> additionalOptionList = optionRepository.findAdditionalOptionList(trimId);
+//
+//        //then
+//
+//    }
+
+    @Test
+    @DisplayName("엔진 ID와 선택된 옵션 ID 목록을 통해 비활성화된 옵션 정보를 반환한다")
+    void findNotActivatedOptionIdList() {
+        //given
+        Long engineId = 1L;
+        List<Long> selectedOptionIds = List.of(15L);
+
+        //when
+        List<Long> notActivatedOptionIdList = optionRepository.findNotActivatedOptionIdList(engineId, selectedOptionIds);
+
+        //then
+        softAssertions.assertThat(notActivatedOptionIdList.size()).isEqualTo(3);
+    }
+
+
+
+}

--- a/backend/src/test/java/com/autoever/idle/domain/option/OptionServiceTest.java
+++ b/backend/src/test/java/com/autoever/idle/domain/option/OptionServiceTest.java
@@ -1,0 +1,97 @@
+package com.autoever.idle.domain.option;
+
+import com.autoever.idle.domain.function.FunctionRepository;
+import com.autoever.idle.domain.function.dto.FunctionDto;
+import com.autoever.idle.domain.option.dto.OptionDto;
+import com.autoever.idle.domain.option.dto.OptionFunctionsDto;
+import com.autoever.idle.domain.option.dto.OptionRequest;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.junit.jupiter.InjectSoftAssertions;
+import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(SoftAssertionsExtension.class)
+@DisplayName("Option Controller Test")
+class OptionServiceTest {
+
+    @Mock
+    private OptionRepository optionRepository;
+    @Mock
+    private FunctionRepository functionRepository;
+    @InjectMocks
+    private OptionService optionService;
+    @InjectSoftAssertions
+    private SoftAssertions softAssertions;
+
+    private List<OptionDto> additionalOptionList = new ArrayList<>();
+    private List<Long> notActivatedOptionIdList = List.of(1L, 15L);
+    private List<OptionFunctionsDto> optionFunctionsDtoList = new ArrayList<>();
+    private List<FunctionDto> functionDtoList = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        functionDtoList.add(new FunctionDto(
+                119L,
+                "러기지 프로텍션 매트",
+                "-",
+                "https://a5idle.s3.ap-northeast-2.amazonaws.com/mycarimages/112-1.jpg",
+                null));
+
+        OptionDto optionDto = new OptionDto(8L,
+                "프로텍션 매트 패키지 I",
+                250000L,
+                "구매자 10%가 선택",
+                "흠집없이 내 차에 짐을 싣고 싶다면?\n프로텍션 매트 패기지1로 흠집 걱정 없이 짐을 실어보세요.",
+                "차량 보호",
+                "false");
+
+        additionalOptionList.add(optionDto);
+
+        OptionFunctionsDto optionFunctionsDto = new OptionFunctionsDto(
+                optionDto.getOptionId(),
+                optionDto.getOptionName(),
+                optionDto.getOptionPrice(),
+                optionDto.getOptionPurchaseRate(),
+                optionDto.getOptionDescription(),
+                optionDto.getOptionCategory(),
+                optionDto.getOptionCanSelect(),
+                functionDtoList
+        );
+        optionFunctionsDtoList.add(optionFunctionsDto);
+    }
+
+    @Test
+    @DisplayName("추가 옵션 정보와 포함하는 기능 정보 목록을 반환한다")
+    void getOptionFunctions() {
+        //given
+        Long trimId = 1L;
+        Long engineId = 1L;
+        OptionRequest optionRequest = new OptionRequest(1L, List.of(1L, 15L), 1L);
+
+        //when
+        when(optionRepository.findAdditionalOptionList(any())).thenReturn(additionalOptionList);
+        when(optionRepository.findNotActivatedOptionIdList(any(), anyList())).thenReturn(notActivatedOptionIdList);
+        when(functionRepository.findFunctionsInAdditionalOption(any())).thenReturn(functionDtoList);
+        List<OptionFunctionsDto> optionFunctions = optionService.getOptionFunctions(optionRequest);
+
+        //then
+        softAssertions.assertThat(optionFunctions.get(0).getOptionId()).isEqualTo(additionalOptionList.get(0).getOptionId());
+        softAssertions.assertThat(optionFunctions.get(0).getOptionName()).isEqualTo(additionalOptionList.get(0).getOptionName());
+        softAssertions.assertThat(optionFunctions.get(0).getFunctions().get(0).getFunctionId()).isEqualTo(functionDtoList.get(0).getFunctionId());
+    }
+}

--- a/backend/src/test/java/com/autoever/idle/domain/option/OptionServiceTest.java
+++ b/backend/src/test/java/com/autoever/idle/domain/option/OptionServiceTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(SoftAssertionsExtension.class)
-@DisplayName("Option Controller Test")
+@DisplayName("Option Service Test")
 class OptionServiceTest {
 
     @Mock


### PR DESCRIPTION
## 🚩 관련 이슈
- #11 

## 📋 구현 기능 명세
- [X] 해당 트림에 대한 추가 옵션 정보 및 옵션 하위 기능 목록 정보 반환
- [X] 추가 옵션 정보 반환 시 정렬(가격순 정렬, 구매자 선택률순, 가나다순)

## 📌 추가 보완할 점
- 예외 처리 미흡
- 테스트 코드 1개가 비정상적으로 작동돼서 주석 처리 해놓은 상황
