### PR TITLE
[FE] 견적서 페이지 데이터 연결 및 컴포넌트 수정

### DIFF
--- a/frontend/Idle/src/components/BillMain/BillDetail.jsx
+++ b/frontend/Idle/src/components/BillMain/BillDetail.jsx
@@ -8,7 +8,6 @@ import { useNavigate } from "react-router-dom";
 
 function BillDetail({ item, data }) {
   const { car } = useContext(carContext);
-  console.log(data);
   const navigate = useNavigate();
   let detail, price, path, imgSrc;
   switch (item) {
@@ -39,10 +38,7 @@ function BillDetail({ item, data }) {
     default:
       break;
   }
-
-
   const isColorTab = (item === "exterior" || item === "interior")
-  console.log(isColorTab);
   return (
     <StContainer>
       <StTitle>

--- a/frontend/Idle/src/components/BillMain/BillDetail.jsx
+++ b/frontend/Idle/src/components/BillMain/BillDetail.jsx
@@ -6,34 +6,43 @@ import ModifyButton from "buttons/ModifyButton";
 import palette from "styles/palette";
 import { useNavigate } from "react-router-dom";
 
-function BillDetail({ item }) {
+function BillDetail({ item, data }) {
   const { car } = useContext(carContext);
+  console.log(data);
   const navigate = useNavigate();
-  let detail, price, path;
+  let detail, price, path, imgSrc;
   switch (item) {
     case "trim":
-      detail = car.trim.name;
+      detail = car.trim.name || "아직 선택하지 않았습니다.";
       price = car.getTrimSum();
       path = `/${item}`;
       break;
     case "engines":
     case "drivingMethods":
     case "bodyTypes":
-      detail = car.detail[item].name;
+      detail = car.detail[item].name || "아직 선택하지 않았습니다.";
       price = car.detail[item].price;
       path = `/detail/${item}`;
       break;
     case "exterior":
-    case "interior":
-      detail = car.color[item].name;
+      detail = null;
       price = car.color[item].price;
       path = `/color/${item}`;
+      imgSrc = data.exterior.exteriorImgUrl;
+      break;
+    case "interior":
+      detail = null;
+      price = car.color[item].price;
+      path = `/color/${item}`;
+      imgSrc = data.interior.interiorImgUrl;
       break;
     default:
       break;
   }
 
 
+  const isColorTab = (item === "exterior" || item === "interior")
+  console.log(isColorTab);
   return (
     <StContainer>
       <StTitle>
@@ -41,7 +50,12 @@ function BillDetail({ item }) {
         <ModifyButton onClick={() => { navigate(path) }} />
       </StTitle>
       <StDetailContainer>
-        <h1>{detail ? detail : "아직 선택하지 않았습니다."}</h1>
+        {detail ? <h1>{detail}</h1> : <></>}
+        {isColorTab ?
+          <StColorContent $img={imgSrc} >
+            <p>{car.color[item].name || ""}</p>
+          </StColorContent> :
+          <></>}
         <p>{price ? price.toLocaleString() : "0"} 원</p>
       </StDetailContainer>
     </StContainer>
@@ -97,3 +111,24 @@ const StDetailContainer = styled.div`
     letter-spacing: -0.66px;
   }
 `;
+
+const StColorContent = styled.div`
+  width: 320px;
+  height: 90px;
+  background-image: ${({ $img }) => `url(${$img})`};
+  flex-shrink: 0;
+  position: relative;
+  p {
+    position:absolute;
+    bottom:8px;
+    left:13px;
+    color: ${palette.White};
+    /* body1 medium */
+    font-family: "Hyundai Sans Text KR";
+    font-size: 16px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 24px; /* 150% */
+    letter-spacing: -0.48px;
+  }
+`

--- a/frontend/Idle/src/components/BillMain/BillMain.jsx
+++ b/frontend/Idle/src/components/BillMain/BillMain.jsx
@@ -5,12 +5,12 @@ import palette from "styles/palette";
 import BillOptionContainer from "billMain/BillOptionContainer";
 import { useContext } from "react";
 import { carContext } from "utils/context";
-function BillMain() {
+function BillMain({ data }) {
   const { car } = useContext(carContext);
   function render(item) {
     return (
       <>
-        <BillDetail item={item} />
+        <BillDetail item={item} data={data} />
         <Division />
       </>
     );

--- a/frontend/Idle/src/components/BillMain/BillMain.jsx
+++ b/frontend/Idle/src/components/BillMain/BillMain.jsx
@@ -19,7 +19,7 @@ function BillMain({ data }) {
     <StContainer>
       <StTitle>기본 견적</StTitle>
       {BILL_LIST.map((item) => render(item))}
-      <BillOptionContainer added={car.option.additional} confused={car.option.confusing} />
+      <BillOptionContainer added={car.option.additional} confused={car.option.confusing} data={data} />
     </StContainer>
   );
 }

--- a/frontend/Idle/src/components/BillMain/BillOptionBox.jsx
+++ b/frontend/Idle/src/components/BillMain/BillOptionBox.jsx
@@ -12,34 +12,16 @@ function BillOptionBox({ isAdded, data }) {
   const { car, dispatch } = useContext(carContext);
 
   function btnClicked() {
-    {
-      /** 본 코드 */
-    }
-    // const payload = {
-    //   name: data.functionOptionName,
-    //   price: data.functionPrice,
-    // };
-
-    {
-      /** 테스트 용 코드 */
-    }
-    const payload = { name: data.name, price: data.price };
-
-    {
-      /** 본 코드 */
-    }
-    // const filteredAdded = car.option.additional.filter(
-    //   (item) => item.name !== data.functionOptionName
-    // );
-    // const filteredConfused = car.option.confusing.filter(
-    //   (item) => item.name !== data.functionOptionName
-    // );
-
-    {
-      /** 테스트 용 코드 */
-    }
-    const filteredAdded = car.option.additional.filter((item) => item.name !== data.name);
-    const filteredConfused = car.option.confusing.filter((item) => item.name !== data.name);
+    const payload = {
+      name: data.functionOptionName,
+      price: data.functionPrice,
+    };
+    const filteredAdded = car.option.additional.filter(
+      (item) => item.name !== data.functionOptionName
+    );
+    const filteredConfused = car.option.confusing.filter(
+      (item) => item.name !== data.functionOptionName
+    );
 
     if (isAdded) {
       dispatch({ type: PUSH_CONFUSING_OPTION, payload: payload });
@@ -52,24 +34,16 @@ function BillOptionBox({ isAdded, data }) {
 
   return (
     <StContainer>
-      {/** 본 코드 */}
-      {/* <StImg src={data.functionImgUrl}></StImg>
+      <StImg src={data.functionImgUrl}></StImg>
       <StContent>
         <StCategory>{data.functionCategory}</StCategory>
         <StOptionName>{data.functionOptionName}</StOptionName>
-        <STOptionDesc>{data.functionOptionDesc}</STOptionDesc>
+        <STOptionDesc>{data.functionDescription}</STOptionDesc>
       </StContent>
       <StBtn onClick={btnClicked} $isAdd={isAdded}>
         {isAdded ? "삭제하기" : "확정하기"}
       </StBtn>
-      <StPrice>+ {data.functionPrice.toLocaleString()} 원</StPrice> */}
-
-      {/** 테스트 용 코드 */}
-      <StContent>{data.name}</StContent>
-      <StBtn onClick={btnClicked} $isAdd={isAdded}>
-        {isAdded ? "삭제하기" : "확정하기"}
-      </StBtn>
-      <StPrice>{data.price}</StPrice>
+      <StPrice>{data.functionPrice.toLocaleString()} 원</StPrice>
     </StContainer>
   );
 }
@@ -108,7 +82,7 @@ const StCategory = styled.div`
 
   color: ${({ theme }) => theme.NavyBlue_5};
   text-align: center;
-  font-family: Hyundai Sans Text KR;
+  font-family: "Hyundai Sans Text KR";
   font-size: 12px;
   font-style: normal;
   font-weight: 500;
@@ -118,15 +92,13 @@ const StCategory = styled.div`
 
 const StOptionName = styled.div`
   color: ${({ theme }) => theme.Black};
-  font-family: Hyundai Sans Text KR;
+  font-family: "Hyundai Sans Text KR";
   font-size: 22px;
   font-style: normal;
   font-weight: 700;
   line-height: 28px;
   letter-spacing: -0.66px;
   text-align: center;
-
-  width: 175px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -135,7 +107,7 @@ const StOptionName = styled.div`
 const STOptionDesc = styled.div`
   width: 202px;
   color: ${({ theme }) => theme.Grey_3};
-  font-family: Hyundai Sans Text KR;
+  font-family: "Hyundai Sans Text KR";
   font-size: 13px;
   font-style: normal;
   font-weight: 400;
@@ -154,7 +126,7 @@ const StBtn = styled.button`
   background-color: ${({ $isAdd }) => ($isAdd ? "#1A3276" : "#9B6D54")};
 
   color: white;
-  font-family: Hyundai Sans Text KR;
+  font-family: "Hyundai Sans Text KR";
   font-size: 13px;
   font-style: normal;
   font-weight: 400;
@@ -166,7 +138,7 @@ const StBtn = styled.button`
 
 const StPrice = styled.div`
   color: ${({ theme }) => theme.Black};
-  font-family: Hyundai Sans Text KR;
+  font-family: "Hyundai Sans Text KR";
   font-size: 22px;
   font-style: normal;
   font-weight: 700;

--- a/frontend/Idle/src/components/BillMain/BillOptionContainer.jsx
+++ b/frontend/Idle/src/components/BillMain/BillOptionContainer.jsx
@@ -1,81 +1,23 @@
 import BillOptionBox from "./BillOptionBox";
-import hyundai from "images/hyundai.svg";
 import { styled } from "styled-components";
 import palette from "../../styles/palette";
 import { useNavigate } from "react-router-dom";
 
-// const additional = [
-//   {
-//     functionId: 1234,
-//     functionOptionName: "주차보조시스템II",
-//     functionCategory: "안전",
-//     functionImgUrl: hyundai,
-//     functionDescription:
-//       "안전한 차량 경험을 위한 여섯 가지 기능 모음 '컴포트 2'를 통해 편리한 드라이빙을 즐겨보세요",
-//     functionPrice: 100000000,
-//   },
-//   {
-//     functionId: 5678,
-//     functionCategory: "내장",
-//     functionOptionName: "현대 스마트 센스",
-//     functionImgUrl: hyundai,
-//     functionDescription:
-//       "안전한 차량 경험을 위한 여섯 가지 기능 모음 '컴포트 2'를 통해 편리한 드라이빙을 즐겨보세요",
-//     functionPrice: 100000000,
-//   },
-//   {
-//     functionId: 9123,
-//     functionCategory: "외장",
-//     functionOptionName: "컴포트 Ⅱ",
-//     functionImgUrl: hyundai,
-//     functionDescription:
-//       "안전한 차량 경험을 위한 여섯 가지 기능 모음 '컴포트 2'를 통해 편리한 드라이빙을 즐겨보세요",
-//     functionPrice: 100000000,
-//   },
-// ];
-
-// const confusing = [
-//   {
-//     functionId: 1234,
-//     functionOptionName: "[N퍼포먼스파츠] 20인치 다크 스퍼터링 휠",
-//     functionCategory: "안전",
-//     functionImgUrl: hyundai,
-//     functionDescription:
-//       "안전한 차량 경험을 위한 여섯 가지 기능 모음 '컴포트 2'를 통해 편리한 드라이빙을 즐겨보세요",
-//     functionPrice: 100000000,
-//   },
-//   {
-//     functionId: 5678,
-//     functionCategory: "내장",
-//     functionOptionName: "[N퍼포먼스파츠] 20인치 다크 스퍼터링 휠",
-//     functionImgUrl: hyundai,
-//     functionDescription:
-//       "안전한 차량 경험을 위한 여섯 가지 기능 모음 '컴포트 2'를 통해 편리한 드라이빙을 즐겨보세요",
-//     functionPrice: 100000000,
-//   },
-//   {
-//     functionId: 9123,
-//     functionCategory: "외장",
-//     functionOptionName: "[N퍼포먼스파츠] 20인치 다크 스퍼터링 휠",
-//     functionImgUrl: hyundai,
-//     functionDescription:
-//       "안전한 차량 경험을 위한 여섯 가지 기능 모음 '컴포트 2'를 통해 편리한 드라이빙을 즐겨보세요",
-//     functionPrice: 100000000,
-//   },
-// ];
-
-function BillOptionContainer({ added, confused }) {
+function BillOptionContainer({ added, confused, data }) {
+  const addedData = data.additionalFunctions.filter((item) => added.some((opt) => opt.name === item.functionOptionName))
+  const confusedData = data.additionalFunctions.filter((item) => confused.some((opt) => opt.name === item.functionOptionName))
   const navigate = useNavigate();
   function renderAddOptions() {
-    return added.map((item, index) => <BillOptionBox isAdded={true} key={index} data={item} />);
+    return addedData.map((item, index) => <BillOptionBox isAdded={true} key={index} data={item} />);
   }
   function renderConfusingOptions() {
-    return confused.map((item, index) => <BillOptionBox isAdded={false} key={index} data={item} />);
+    return confusedData.map((item, index) => <BillOptionBox isAdded={false} key={index} data={item} />);
   }
 
   function changeOptionBtnClicked() {
-    navigate("/option");
+    navigate("/option/all");
   }
+
   return (
     <StContainer>
       <StTop>
@@ -85,12 +27,12 @@ function BillOptionContainer({ added, confused }) {
 
       <StMain>
         <StChangeBtn onClick={changeOptionBtnClicked}>변경하기 {">"}</StChangeBtn>
+        { }
         <div style={{ display: "flex", flexDirection: "column" }}>
           <StOptionType>추가 옵션</StOptionType>
-          <StBlock>{renderAddOptions()}</StBlock>
-
+          <StBlock>{added.length ? renderAddOptions() : "추가한 옵션이 없습니다."}</StBlock>
           <StOptionType>고민 옵션</StOptionType>
-          <StBlock>{renderConfusingOptions()}</StBlock>
+          <StBlock>{confused.length ? renderConfusingOptions() : "고민한 옵션이 없습니다."}</StBlock>
         </div>
       </StMain>
     </StContainer>
@@ -109,7 +51,7 @@ const StTop = styled.div`
 `;
 const StTitle = styled.div`
   color: ${palette.Black};
-  font-family: Hyundai Sans Head KR;
+  font-family: "Hyundai Sans Head KR";
   font-size: 24px;
   font-style: normal;
   font-weight: 500;
@@ -118,7 +60,7 @@ const StTitle = styled.div`
 `;
 const StSub = styled.div`
   color: ${palette.CoolGrey_3};
-  font-family: Hyundai Sans Text KR;
+  font-family: "Hyundai Sans Text KR";
   font-size: 20px;
   font-style: normal;
   font-weight: 500;
@@ -135,7 +77,7 @@ const StMain = styled.div`
 
 const StChangeBtn = styled.div`
   color: ${palette.CoolGrey_2};
-  font-family: Hyundai Sans Text KR;
+  font-family: "Hyundai Sans Text KR";
   font-size: 16px;
   font-style: normal;
   font-weight: 500;
@@ -151,7 +93,7 @@ const StOptionType = styled.p`
   width: 78px;
   height: 33px;
   color: ${palette.Black};
-  font-family: Hyundai Sans Text KR;
+  font-family: "Hyundai Sans Text KR";
   font-size: 22px;
   font-style: normal;
   font-weight: 700;

--- a/frontend/Idle/src/pages/billPage.jsx
+++ b/frontend/Idle/src/pages/billPage.jsx
@@ -24,23 +24,23 @@ const dummyData = {
       "functionPrice": 100000000,
       "functionCategory": "안전",
       "functionImgUrl": "...",
-      "functionDescription": "..."
+      "functionDescription": "옵션 설명옵션 설명옵션 설명 옵션 설명옵"
     },
     {
       "functionId": 5678,
-      "functionOptionName": "주차보조시스템II",
+      "functionOptionName": "현대 스마트 센스",
       "functionPrice": 100000000,
       "functionCategory": "내장",
       "functionImgUrl": "...",
-      "functionDescription": "..."
+      "functionDescription": "옵션 설명옵션 설명옵션 설명 옵션 설명옵"
     },
     {
       "functionId": 9123,
-      "functionOptionName": "주차보조시스템II",
+      "functionOptionName": "컴포트 Ⅱ",
       "functionPrice": 100000000,
       "functionCategory": "외장",
       "functionImgUrl": "...",
-      "functionDescription": "..."
+      "functionDescription": "옵션 설명옵션 설명옵션 설명 옵션 설명옵"
     }
   ]
 }

--- a/frontend/Idle/src/pages/billPage.jsx
+++ b/frontend/Idle/src/pages/billPage.jsx
@@ -1,5 +1,4 @@
 import { styled } from "styled-components";
-
 import Header from "layout/Header";
 import Car3D from "content/Car3D";
 import WhiteButton from "buttons/WhiteButton";
@@ -8,6 +7,43 @@ import { useContext, useState } from "react";
 import { carContext } from "utils/context";
 import BillMain from "billMain/BillMain";
 import MapModal from "../components/BillMain/MapModal";
+
+const dummyData = {
+  "exterior": {
+    "exteriorId": 1,
+    "exteriorImgUrl": "https://a5idle.s3.ap-northeast-2.amazonaws.com/mycarimages/11.png"
+  },
+  "interior": {
+    "interiorId": 111,
+    "interiorImgUrl": "https://a5idle.s3.ap-northeast-2.amazonaws.com/mycarimages/122-1.png"
+  },
+  "additionalFunctions": [
+    {
+      "functionId": 1234,
+      "functionOptionName": "주차보조시스템II",
+      "functionPrice": 100000000,
+      "functionCategory": "안전",
+      "functionImgUrl": "...",
+      "functionDescription": "..."
+    },
+    {
+      "functionId": 5678,
+      "functionOptionName": "주차보조시스템II",
+      "functionPrice": 100000000,
+      "functionCategory": "내장",
+      "functionImgUrl": "...",
+      "functionDescription": "..."
+    },
+    {
+      "functionId": 9123,
+      "functionOptionName": "주차보조시스템II",
+      "functionPrice": 100000000,
+      "functionCategory": "외장",
+      "functionImgUrl": "...",
+      "functionDescription": "..."
+    }
+  ]
+}
 
 function BillPage() {
   const { car } = useContext(carContext);
@@ -42,7 +78,7 @@ function BillPage() {
             <BlueButton text={"카마스터 찾기"} onClick={carMasterBtnClicked} />
           </StButtonContainer>
         </StConfirmContainer>
-        <BillMain />
+        <BillMain data={dummyData} />
         {carMasterVisible && <MapModal setCarMasterVisible={setCarMasterVisible} />}
       </StContainer>
     </StWrapper>


### PR DESCRIPTION
## 🚩 관련 이슈
- close #123 

## 📋 구현 기능 명세
- [x] 외장, 내장 색상 데이터 연결
- [x] 추가 옵션, 고민중인 옵션 데이터 연결

## 📌 PR Point
- 추가 옵션과, 고민중인옵션을 통신한 데이터의 배열과 비교를 해야했는데 둘다 객체가 들어있는 배열이라 fliter거는 것이 어려웠다
- 구글링을 통해 some 이라는 함수를 알게 되었고, 
```javascript
const addedData = data.additionalFunctions.filter((item) => added.some((opt) => opt.name === item.functionOptionName))
```
이런식으로 fliter를 주었다



## 📸 결과물 스크린샷
<img width="892" alt="스크린샷 2023-08-16 오전 12 06 56" src="https://github.com/softeerbootcamp-2nd/A5-Idle/assets/39405559/a3ca6dba-d9c1-4881-8c3c-4fc2d1bc922f">
