### PR TITLE
[FE] 옵션 포함 상태에서 트림 변경시 경고 모달 출력

### DIFF
--- a/frontend/Idle/src/components/common/boxs/NormalTrimBox.jsx
+++ b/frontend/Idle/src/components/common/boxs/NormalTrimBox.jsx
@@ -5,6 +5,8 @@ import { carContext } from "utils/context";
 import TrimDetailModal from "trimDetailModal/TrimDetailModal";
 import { CHANGE_TRIM } from "utils/actionType";
 import palette from "styles/palette";
+import WarningModal from "../modals/WarningModal";
+import { CLEAR_OPTION } from "../../../utils/actionType";
 
 function NormalTrimBox({
   purchaseRate,
@@ -17,16 +19,29 @@ function NormalTrimBox({
 }) {
   const { car, dispatch } = useContext(carContext);
   const [isModal, setIsModal] = useState(false);
+  const [isWarning, setIsWarning] = useState(false);
+  const [tempPayload, setTempPayload] = useState({})
 
+  function alertSubmit() {
+    dispatch({ type: CLEAR_OPTION, payload: tempPayload })
+    setIsWarning(false)
+  }
   function trimClicked(name, price, trimId) {
+
     if (car.trim.name !== name) {
-      const payload = {
+      setTempPayload({
         trimId: trimId,
         name: name,
         price: price,
-      };
-
-      dispatch({ type: CHANGE_TRIM, payload: payload });
+      })
+      if (car.option.additional.length !== 0) setIsWarning(true)
+      else dispatch({
+        type: CHANGE_TRIM, payload: {
+          trimId: trimId,
+          name: name,
+          price: price,
+        }
+      });
     }
   }
 
@@ -36,6 +51,7 @@ function NormalTrimBox({
   function setModalOff() {
     setIsModal(false);
   }
+  console.log(car);
   const isTrimSelected = car.trim.name === name;
   return (
     <>
@@ -67,6 +83,14 @@ function NormalTrimBox({
           defaultFunctions={defaultFunctions}
         />
       )}
+      {isWarning ? (
+        <WarningModal
+          title={"트림을 변경하시겠습니까?"}
+          setModalVisible={setIsWarning}
+          onSubmitClick={alertSubmit}
+          detail={"현재까지의 변경사항은 저장되지 않습니다."}
+        />
+      ) : null}
     </>
   );
 }

--- a/frontend/Idle/src/components/common/logos/MainLogoBlack.jsx
+++ b/frontend/Idle/src/components/common/logos/MainLogoBlack.jsx
@@ -1,11 +1,20 @@
 import styled from "styled-components";
 import { ReactComponent as MainLogoImg } from "images/hyundai.svg";
 import WarningModal from "modals/WarningModal";
-import { useState } from "react";
+import { useContext, useState } from "react";
 import palette from "styles/palette";
+import { useNavigate } from "react-router-dom";
+import { carContext } from "../../../utils/context"
+import { RESET_ALL } from "../../../utils/actionType"
 
 function MainLogoBlack() {
   const [modalVisible, setModalVisible] = useState(false);
+  const navigate = useNavigate();
+  const { dispatch } = useContext(carContext);
+  function resetPage() {
+    dispatch({ type: RESET_ALL, payload: null });
+    navigate("/");
+  }
 
   function logoClicked() {
     setModalVisible(true);
@@ -20,6 +29,7 @@ function MainLogoBlack() {
         <WarningModal
           title={"마이 카마스터를 종료하시겠습니까?"}
           setModalVisible={setModalVisible}
+          onSubmitClick={resetPage}
         />
       ) : null}
     </Stdiv>

--- a/frontend/Idle/src/components/common/modals/WarningModal.jsx
+++ b/frontend/Idle/src/components/common/modals/WarningModal.jsx
@@ -1,10 +1,6 @@
 import styled from "styled-components";
-import { useContext } from "react";
 import BlueButton from "buttons/BlueButton";
 import WhiteButton from "buttons/WhiteButton";
-import { RESET_ALL } from "utils/actionType";
-import { carContext } from "utils/context";
-import { useNavigate } from "react-router-dom";
 import { createPortal } from "react-dom";
 import palette from "styles/palette";
 
@@ -13,28 +9,20 @@ import palette from "styles/palette";
  * @param {string} title 질문내용 (문자열)
  * @returns 모달창
  */
-function WarningModal({ title, setModalVisible }) {
-  const navigate = useNavigate();
-
-  const { dispatch } = useContext(carContext);
-
+function WarningModal({ title, setModalVisible, onSubmitClick, detail = "" }) {
   function clickCancel() {
     setModalVisible(false);
-  }
-  function clickCheck() {
-    dispatch({ type: RESET_ALL, payload: null });
-    navigate("/");
   }
 
   return createPortal(
     <ModalContainer>
       <ModalBackground />
-
       <StContainer>
         <StTitle>{title}</StTitle>
+        {detail && <p>{detail}</p>}
         <StBtnContainer>
           <WhiteButton text={"취소"} onClick={clickCancel} />
-          <BlueButton text={"확인"} onClick={clickCheck} />
+          <BlueButton text={"확인"} onClick={() => onSubmitClick()} />
         </StBtnContainer>
       </StContainer>
     </ModalContainer>,
@@ -51,10 +39,19 @@ const StContainer = styled.div`
   padding: 48px 44px;
   background: ${palette.White};
   flex-direction: column;
-  justify-content: center;
+  justify-content: space-between;
   align-items: center;
-  gap: 48px;
   z-index: 100;
+  p{color:${palette.Black};
+    text-align: center;
+    /* body 1 regular */
+    font-family: "Hyundai Sans Text KR";
+    font-size: 16px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 24px; /* 150% */
+    letter-spacing: -0.48px;
+    }
 `;
 
 const StTitle = styled.div`

--- a/frontend/Idle/src/pages/trimPage.jsx
+++ b/frontend/Idle/src/pages/trimPage.jsx
@@ -28,7 +28,7 @@ function TrimPage() {
   const filteredData = trimData?.filter((item) => item.name === car.trim.name);
   return (
     <>
-      {filteredData ? <StImageContainer src={filteredData[0].imgUrl} /> : <p>Loading...</p>}
+      {filteredData ? <StImageContainer src={filteredData[0]?.imgUrl} /> : <p>Loading...</p>}
       <StWrapper>
         <StBottomContainer>
           {trimData ? <TrimBoxContainer data={trimData} /> : <p>Loading...</p>}

--- a/frontend/Idle/src/utils/actionType.jsx
+++ b/frontend/Idle/src/utils/actionType.jsx
@@ -23,3 +23,4 @@ export const SET_DISABLE_FUNCTION_ID = "set_disable_function_id";
 export const CLEAR_FUNCTIONS_OPTIONS = "clear_functions_options";
 export const PUSH_DISABLE_FUNCTION_ID = "push_disable_function_id";
 export const PUSH_OPTION_ALERT = "push_option_alert";
+export const CLEAR_OPTION = "clear_option";

--- a/frontend/Idle/src/utils/reducer.jsx
+++ b/frontend/Idle/src/utils/reducer.jsx
@@ -23,6 +23,7 @@ import {
   SET_DISABLE_FUNCTION_ID,
   CHANGE_INTERIOR_COLOR,
   CHANGE_EXTERIOR_COLOR,
+  CLEAR_OPTION,
 } from "./actionType";
 
 export function findTrimReducer(state, { type, payload }) {
@@ -163,6 +164,15 @@ export function carReducer(car, { type, payload }) {
         },
       };
 
+    case CLEAR_OPTION:
+      return {
+        ...car,
+        trim: payload,
+        option: {
+          additional: [],
+          confusing: [],
+        },
+      }
     case RESET_ALL:
       return {
         ...car,


### PR DESCRIPTION
## 🚩 관련 이슈
- close #221 

## 📋 구현 기능 명세
- [x] reducer 수정
- [x] 경고 모달 재사용을 위한 수정
- [x] 경고 모달 사용중인 로고 컴포넌트 수정
- [x] 중간 디테일 멘트 prop 추가

## 📌 PR Point
- 경고모달에서의 온클릭을 분리하였습니다.
- detail 설명에 들어갈 prop을 defalt는 ""로 추가하여 재사용하였습니다
- 트림 추가하는 reducer 말고 옵션을 지우면서 트림을 업데이트하는 reducer를 추가하였습니다.

## 📸 결과물 스크린샷
<img width="673" alt="스크린샷 2023-08-16 오후 5 59 12" src="https://github.com/softeerbootcamp-2nd/A5-Idle/assets/39405559/3b61e278-a49d-4ff5-9c0b-8706da91bd12">

