### PR TITLE
[feat] 견적서에서 추가 옵션 선택안했을 때 빈 배열 반환하도록 수정

### DIFF
--- a/backend/src/main/java/com/autoever/idle/domain/bill/BillService.java
+++ b/backend/src/main/java/com/autoever/idle/domain/bill/BillService.java
@@ -38,7 +38,14 @@ public class BillService {
         InteriorBillDto interiorBillDto = interiorColorRepository.findInteriorBill(billRequestDto.getInteriorId())
                 .orElseThrow(() -> new InvalidInteriorException(ErrorCode.INVALID_INTERIOR));
 
-        List<SelectedOptionDto> selectedOptions = optionRepository.findSelectedOptions(billRequestDto.getSelectedOptionIds());
+        List<SelectedOptionDto> selectedOptions;
+
+        if (billRequestDto.getSelectedOptionIds().isEmpty()) {
+            selectedOptions = new ArrayList<>();
+        } else {
+            selectedOptions = optionRepository.findSelectedOptions(billRequestDto.getSelectedOptionIds());
+        }
+
         List<FunctionCategoryDto> categories = functionCategoryRepository.findAll();
         List<DefaultFunctionCategoryResDto> categoryDtos = new ArrayList<>();
 


### PR DESCRIPTION
## 🚩 관련 이슈
- #225 

## 📋 구현 기능 명세
- [x] 견적서에 추가 옵션이 없을 때 에러 발생하는 코드 수정
