### PR TITLE
[FE] 기본 포함 옵션 모달 기능 추가

### DIFF
--- a/frontend/Idle/src/components/BillMain/BillOptionContainer.jsx
+++ b/frontend/Idle/src/components/BillMain/BillOptionContainer.jsx
@@ -2,8 +2,13 @@ import BillOptionBox from "./BillOptionBox";
 import { styled } from "styled-components";
 import palette from "../../styles/palette";
 import { useNavigate } from "react-router-dom";
+import { useContext, useState } from "react";
+import TrimDetailModal from "../trimDetailModal/TrimDetailModal";
+import { carContext } from "../../utils/context"
 
 function BillOptionContainer({ added, confused, data }) {
+  const [isOpen, setIsOpen] = useState(false)
+  const { car } = useContext(carContext)
   const addedData = data && data?.selectedOptions.filter((item) => added.some((opt) => opt.name === item.optionName))
   const confusedData = data && data?.selectedOptions.filter((item) => confused.some((opt) => opt.name === item.optionName))
   const navigate = useNavigate();
@@ -22,7 +27,7 @@ function BillOptionContainer({ added, confused, data }) {
     <StContainer>
       <StTop>
         <StTitle>옵션</StTitle>
-        <StSub>기본 포함 옵션 {">"}</StSub>
+        <StSub onClick={() => { setIsOpen(true) }}>기본 포함 옵션 {">"}</StSub>
       </StTop>
 
       <StMain>
@@ -34,6 +39,7 @@ function BillOptionContainer({ added, confused, data }) {
           <StBlock>{confused.length ? renderConfusingOptions() : "고민한 옵션이 없습니다."}</StBlock>
         </div>
       </StMain>
+      {isOpen ? <TrimDetailModal trim={car.trim.name} desc={data?.trimDescription} setModalOff={() => { setIsOpen(false) }} defaultFunctions={data?.defaultFunctions} modalPosition={"carMasterModal"} /> : null}
     </StContainer>
   );
 }
@@ -66,6 +72,7 @@ const StSub = styled.div`
   line-height: 28px;
   letter-spacing: -0.6px;
   text-align: right;
+  cursor: pointer;
 `;
 
 const StMain = styled.div`

--- a/frontend/Idle/src/components/common/boxs/NormalTrimBox.jsx
+++ b/frontend/Idle/src/components/common/boxs/NormalTrimBox.jsx
@@ -80,6 +80,7 @@ function NormalTrimBox({
           desc={description}
           setModalOff={setModalOff}
           defaultFunctions={defaultFunctions}
+          modalPosition={"modal"}
         />
       )}
       {isWarning ? (

--- a/frontend/Idle/src/components/trimDetailModal/TrimDetailModal.jsx
+++ b/frontend/Idle/src/components/trimDetailModal/TrimDetailModal.jsx
@@ -5,7 +5,7 @@ import { ReactComponent as EscapeButton } from "images/esc.svg";
 import palette from "styles/palette";
 import { useState } from "react";
 
-function TrimDetailModal({ trim, desc, setModalOff, defaultFunctions }) {
+function TrimDetailModal({ trim, desc, setModalOff, defaultFunctions, modalPosition }) {
   const [animationstate, setAnimationstate] = useState(false);
 
   function modalOff() {
@@ -22,7 +22,7 @@ function TrimDetailModal({ trim, desc, setModalOff, defaultFunctions }) {
           <StHeaderContainer>
             <StHeader>
               {trim}
-              <EscapeButton onClick={modalOff} />
+              <EscapeButton style={{ cursor: "pointer" }} onClick={modalOff} />
             </StHeader>
             <Description>{desc}</Description>
           </StHeaderContainer>
@@ -34,7 +34,7 @@ function TrimDetailModal({ trim, desc, setModalOff, defaultFunctions }) {
         </StContainer>
       </StModal>
     </ModalContainer>,
-    document.getElementById("modal")
+    document.getElementById(modalPosition)
   );
 }
 
@@ -45,12 +45,11 @@ const ModalContainer = styled.div`
   top: 0;
   left: 0;
   width: 1280px;
-  height: 720px;
+  height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
   transition: opacity 0.1s ease-in-out;
-  /* opacity: ${({ $animationstate }) => ($animationstate ? 0 : 1)}; */
   animation: ${({ $animationstate }) => ($animationstate ? fadeOut : fadeIn)} 0.3s ease;
 `;
 const fadeIn = keyframes`
@@ -133,7 +132,7 @@ const StOptionContainer = styled.ul`
   flex-direction: column;
   align-items: center;
   gap: 12px;
-  height: 400px;
+  height: 370px;
   overflow: auto;
   margin-left: 20px;
   &::-webkit-scrollbar {


### PR DESCRIPTION
## 🚩 관련 이슈
- close #234 

## 📋 구현 기능 명세
- [x] api 데이터 확인
- [x] 데이터 공용 모달창에 연결
- [x] 모달 생성 위치 전달하는 prop 추가
- [x] 모달 css 변경

## 📌 PR Point
- 모달을 layout의 id 값을 "modal"로 가지고 있는 container에 생성을 해주고 있었는데, billPage에서는 해당 컨테이너로 감싸져있지 않아 id값을 prop으로 받아 렌더링 하는 방식으로 컴포넌트를 수정하여 재사용하였습니다.

## 📸 결과물 스크린샷
<img width="680" alt="스크린샷 2023-08-17 오후 12 55 11" src="https://github.com/softeerbootcamp-2nd/A5-Idle/assets/39405559/81037e50-365a-4c9e-9a1c-fec4e56cf6cc">
