### PR TITLE
[FE] 트림페이지 자세히보기 버그 수정

### DIFF
--- a/frontend/Idle/src/components/common/boxs/NormalTrimBox.jsx
+++ b/frontend/Idle/src/components/common/boxs/NormalTrimBox.jsx
@@ -101,7 +101,7 @@ const StContainer = styled.div`
   height: 138px;
   padding: 12px 24px;
   border: 1px solid
-    ${({ $isSelected }) => ($isSelected ? `${palette.NavyBlue_5}` : `${palette.Grey_2}`)};
+    ${({ $isSelected }) => ($isSelected ? `${palette.NavyBlue_5}` : `${palette.Purple}`)};
   background: ${({ $isSelected }) => ($isSelected ? `${palette.NavyBlue_5}` : `${palette.White}`)};
   flex-direction: column;
   justify-content: center;

--- a/frontend/Idle/src/components/common/boxs/NormalTrimBox.jsx
+++ b/frontend/Idle/src/components/common/boxs/NormalTrimBox.jsx
@@ -6,7 +6,7 @@ import TrimDetailModal from "trimDetailModal/TrimDetailModal";
 import { CHANGE_TRIM } from "utils/actionType";
 import palette from "styles/palette";
 import WarningModal from "../modals/WarningModal";
-import { CLEAR_OPTION } from "../../../utils/actionType";
+import { CLEAR_OPTION } from "utils/actionType";
 
 function NormalTrimBox({
   purchaseRate,
@@ -20,28 +20,30 @@ function NormalTrimBox({
   const { car, dispatch } = useContext(carContext);
   const [isModal, setIsModal] = useState(false);
   const [isWarning, setIsWarning] = useState(false);
-  const [tempPayload, setTempPayload] = useState({})
+  const [tempPayload, setTempPayload] = useState({});
 
   function alertSubmit() {
-    dispatch({ type: CLEAR_OPTION, payload: tempPayload })
-    setIsWarning(false)
+    dispatch({ type: CLEAR_OPTION, payload: tempPayload });
+    setIsWarning(false);
   }
   function trimClicked(name, price, trimId) {
-
     if (car.trim.name !== name) {
       setTempPayload({
         trimId: trimId,
         name: name,
         price: price,
-      })
-      if (car.option.additional.length !== 0 || car.color.exterior.name !== undefined) setIsWarning(true)
-      else dispatch({
-        type: CHANGE_TRIM, payload: {
-          trimId: trimId,
-          name: name,
-          price: price,
-        }
       });
+      if (car.option.additional.length !== 0 || car.color.exterior.name !== undefined)
+        setIsWarning(true);
+      else
+        dispatch({
+          type: CHANGE_TRIM,
+          payload: {
+            trimId: trimId,
+            name: name,
+            price: price,
+          },
+        });
     }
   }
 
@@ -54,12 +56,8 @@ function NormalTrimBox({
   const isTrimSelected = car.trim.name === name;
   return (
     <>
-      <StContainer
-        onClick={() => trimClicked(name, price, trimId)}
-        $isSelected={isTrimSelected}
-        $isActive={isActive}
-      >
-        <StContent>
+      <StContainer $isSelected={isTrimSelected} $isActive={isActive}>
+        <StContent onClick={() => trimClicked(name, price, trimId)}>
           <StTitleContainer>
             <StContentHeader>
               <TitleDetail $isSelected={isTrimSelected}>{purchaseRate}</TitleDetail>
@@ -114,7 +112,7 @@ const StContainer = styled.div`
   opacity: ${({ $isActive }) => ($isActive ? 1 : 0.2)};
   &:hover {
     background: ${({ $isSelected }) =>
-    $isSelected ? `${palette.NavyBlue_5}` : `${palette.NavyBlue_1}`};
+      $isSelected ? `${palette.NavyBlue_5}` : `${palette.NavyBlue_1}`};
     opacity: 0.9;
     cursor: pointer;
   }

--- a/frontend/Idle/src/components/common/boxs/OptionBox.jsx
+++ b/frontend/Idle/src/components/common/boxs/OptionBox.jsx
@@ -109,7 +109,7 @@ const StContainer = styled.div`
       if ($isSelected) {
         switch ($state) {
           case NONE:
-            return `${palette.NavyBlue_1}`;
+            return `${palette.NavyBlue_5}`;
           case CONFUSE:
             return `${palette.Gold_5}`;
           case ADD:

--- a/frontend/Idle/src/components/findTrim/TrimBox.jsx
+++ b/frontend/Idle/src/components/findTrim/TrimBox.jsx
@@ -56,7 +56,7 @@ function TrimBox({
         <StTrimBoxTitle $isselected={isSelected}>{name}</StTrimBoxTitle>
         <StTrimBoxContent $isselected={isSelected}>{description}</StTrimBoxContent>
         <StTrimBoxBottom>
-          <StTrimBoxPrice $isselected={isSelected}>{price} 원</StTrimBoxPrice>
+          <StTrimBoxPrice $isselected={isSelected}>{price.toLocaleString()} 원</StTrimBoxPrice>
           {isActive ? <TrimBoxOptionStatus status={optionStatusProp} /> : null}
         </StTrimBoxBottom>
       </StTrimBox>


### PR DESCRIPTION
## 🚩 관련 이슈
- close #248

## 📋 구현 기능 명세
- [x] 자세히보기를 누를 시, 해당 트림이 선택안됨
- [x] 세부옵션에서 border를 다르게설정했습니다. 

## 📌 PR Point
한단계 낮은 컨테이너에 onClick을 달았습니다.

## 📸 결과물 스크린샷
