### PR TITLE
[FE] 차객체에서 외장색상 첫 사진을 차객체에서 저장하고, 견적서 완성에서 띄우기

### DIFF
--- a/frontend/Idle/src/components/BillMain/BillDetail.jsx
+++ b/frontend/Idle/src/components/BillMain/BillDetail.jsx
@@ -38,20 +38,26 @@ function BillDetail({ item, data }) {
     default:
       break;
   }
-  const isColorTab = (item === "exterior" || item === "interior")
+  const isColorTab = item === "exterior" || item === "interior";
   return (
     <StContainer>
       <StTitle>
         <h1>{TRANSLATE[item]}</h1>
-        <ModifyButton onClick={() => { navigate(path) }} />
+        <ModifyButton
+          onClick={() => {
+            navigate(path);
+          }}
+        />
       </StTitle>
       <StDetailContainer>
         {detail ? <h1>{detail}</h1> : <></>}
-        {isColorTab ?
-          <StColorContent $img={imgSrc} >
+        {isColorTab ? (
+          <StColorContent $img={imgSrc}>
             <p>{car.color[item].name || ""}</p>
-          </StColorContent> :
-          <></>}
+          </StColorContent>
+        ) : (
+          <></>
+        )}
         <p>{price ? price.toLocaleString() : "0"} 원</p>
       </StDetailContainer>
     </StContainer>
@@ -115,11 +121,10 @@ const StColorContent = styled.div`
   flex-shrink: 0;
   position: relative;
   p {
-    position:absolute;
-    bottom:8px;
-    left:13px;
+    position: absolute;
+    bottom: 8px;
+    left: 13px;
     color: ${palette.White};
-    /* body1 medium */
     font-family: "Hyundai Sans Text KR";
     font-size: 16px;
     font-style: normal;
@@ -128,4 +133,4 @@ const StColorContent = styled.div`
     letter-spacing: -0.48px;
     text-shadow: 2px 2px 6px black;
   }
-`
+`;

--- a/frontend/Idle/src/pages/billPage.jsx
+++ b/frontend/Idle/src/pages/billPage.jsx
@@ -54,9 +54,7 @@ function BillPage() {
           카마스터 찾기를 통해 구매 상담을 할 수 있어요
         </TitleContainer>
         <BlueBG />
-        <CarContainer>
-          <Car3D />
-        </CarContainer>
+        <CarContainer $src={JSON.stringify(car.carImg)} />
         <BlueBgBottom />
         <StConfirmContainer>
           <StConfirmText>
@@ -146,11 +144,13 @@ const StTitle = styled.h1`
 `;
 const CarContainer = styled.div`
   position: absolute;
-  width: 573px;
-  height: 359px;
+  width: 860px;
+  height: 471px;
   flex-shrink: 0;
-  top: 100px;
+  top: 130px;
   left: 50px;
+  background-image: url(${({ $src }) => $src});
+  z-index: 100;
 `;
 const StConfirmContainer = styled.div`
   display: flex;

--- a/frontend/Idle/src/pages/colorPage.jsx
+++ b/frontend/Idle/src/pages/colorPage.jsx
@@ -15,7 +15,7 @@ import Car3D from "content/Car3D";
 import OutsideColorBoxContainer from "colorSelection/OutsideColorBoxContainer";
 import InnerColorBoxContainer from "colorSelection/InnerColorBoxContainer";
 import InnerColorContent from "content/InnerColorContent";
-import { CHANGE_EXTERIOR_COLOR, CHANGE_INTERIOR_COLOR } from "../utils/actionType";
+import { CHANGE_EXTERIOR_COLOR, CHANGE_INTERIOR_COLOR, SET_CAR_IMG } from "../utils/actionType";
 import { getAPI } from "../utils/api";
 import { DEFAULT_INTERIROR_COLOR, PATH } from "../utils/constants";
 
@@ -56,6 +56,8 @@ function ColorPage() {
     getAPI(PATH.COLOR.EXTERIOR, { trimId: car.trim.trimId }).then((result) => {
       setExteriorData(result);
       cachedExterior = result;
+      console.log(result);
+      dispatch({ type: SET_CAR_IMG }, result[0].carImgUrls[0]);
     });
   }, []);
 
@@ -67,6 +69,7 @@ function ColorPage() {
       }).then((result) => {
         setInteriorData(result);
         cachedInterior = result;
+        dispatch({ type: SET_CAR_IMG }, result[0].carImgUrls[0]);
       });
     }
   }, [exteriorData]);

--- a/frontend/Idle/src/pages/colorPage.jsx
+++ b/frontend/Idle/src/pages/colorPage.jsx
@@ -15,9 +15,9 @@ import Car3D from "content/Car3D";
 import OutsideColorBoxContainer from "colorSelection/OutsideColorBoxContainer";
 import InnerColorBoxContainer from "colorSelection/InnerColorBoxContainer";
 import InnerColorContent from "content/InnerColorContent";
-import { CHANGE_EXTERIOR_COLOR, CHANGE_INTERIOR_COLOR, SET_CAR_IMG } from "../utils/actionType";
-import { getAPI } from "../utils/api";
-import { DEFAULT_INTERIROR_COLOR, PATH } from "../utils/constants";
+import { CHANGE_EXTERIOR_COLOR, CHANGE_INTERIOR_COLOR, SET_CAR_IMG } from "utils/actionType";
+import { getAPI } from "utils/api";
+import { DEFAULT_INTERIROR_COLOR, PATH } from "utils/constants";
 
 let cachedExterior = null;
 let cachedInterior = null;
@@ -56,8 +56,7 @@ function ColorPage() {
     getAPI(PATH.COLOR.EXTERIOR, { trimId: car.trim.trimId }).then((result) => {
       setExteriorData(result);
       cachedExterior = result;
-      console.log(result);
-      dispatch({ type: SET_CAR_IMG }, result[0].carImgUrls[0]);
+      dispatch({ type: SET_CAR_IMG, payload: result[0].carImgUrls[0].imgUrl });
     });
   }, []);
 
@@ -69,7 +68,6 @@ function ColorPage() {
       }).then((result) => {
         setInteriorData(result);
         cachedInterior = result;
-        dispatch({ type: SET_CAR_IMG }, result[0].carImgUrls[0]);
       });
     }
   }, [exteriorData]);

--- a/frontend/Idle/src/utils/actionType.jsx
+++ b/frontend/Idle/src/utils/actionType.jsx
@@ -24,3 +24,4 @@ export const CLEAR_FUNCTIONS_OPTIONS = "clear_functions_options";
 export const PUSH_DISABLE_FUNCTION_ID = "push_disable_function_id";
 export const PUSH_OPTION_ALERT = "push_option_alert";
 export const CLEAR_OPTION = "clear_option";
+export const SET_CAR_IMG = "set_car_img";

--- a/frontend/Idle/src/utils/constants.jsx
+++ b/frontend/Idle/src/utils/constants.jsx
@@ -271,7 +271,7 @@ export const emptyCar = {
     }
     return false;
   },
-  carImg: "",
+  carImg: {},
 };
 
 export const findTrimInitialState = {

--- a/frontend/Idle/src/utils/constants.jsx
+++ b/frontend/Idle/src/utils/constants.jsx
@@ -271,6 +271,7 @@ export const emptyCar = {
     }
     return false;
   },
+  carImg: "",
 };
 
 export const findTrimInitialState = {

--- a/frontend/Idle/src/utils/globalCar.jsx
+++ b/frontend/Idle/src/utils/globalCar.jsx
@@ -18,6 +18,7 @@ export const globalCar = {
     confusing: [],
   },
   bill: {},
+  carImg: {},
   getTrimSum: function () {
     return this.trim.price !== undefined ? this.trim.price : 0;
   },
@@ -65,5 +66,4 @@ export const globalCar = {
     }
     return false;
   },
-  carImg: "",
 };

--- a/frontend/Idle/src/utils/globalCar.jsx
+++ b/frontend/Idle/src/utils/globalCar.jsx
@@ -65,4 +65,5 @@ export const globalCar = {
     }
     return false;
   },
+  carImg: "",
 };

--- a/frontend/Idle/src/utils/reducer.jsx
+++ b/frontend/Idle/src/utils/reducer.jsx
@@ -21,6 +21,7 @@ import {
   SET_OPTION_STATUS,
   SET_SHOWOPTION_ALERT,
   SET_DISABLE_FUNCTION_ID,
+  SET_CAR_IMG,
   CHANGE_INTERIOR_COLOR,
   CHANGE_EXTERIOR_COLOR,
   CLEAR_OPTION,
@@ -176,7 +177,7 @@ export function carReducer(car, { type, payload }) {
           additional: [],
           confusing: [],
         },
-      }
+      };
     case RESET_ALL:
       return {
         ...car,
@@ -199,6 +200,11 @@ export function carReducer(car, { type, payload }) {
       return {
         ...car,
         ...payload,
+      };
+    case SET_CAR_IMG:
+      return {
+        ...car,
+        carImg: payload,
       };
   }
 }


### PR DESCRIPTION
## 🚩 관련 이슈
- close #259

## 📋 구현 기능 명세
- [x] 외장사진페이지에서 첫번째 사진을 차객체에 저장하기
- [x] 견적서 완성페이지에서 차객체에 저장된 사진을 띄운다.

## 📌 PR Point
차객체에서 carImg 란 값을 넣었고, carReducer에서 carImg값을 바꾸는 dispatch를 설정했습니다.

## 📸 결과물 스크린샷

<img width="1276" alt="image" src="https://github.com/softeerbootcamp-2nd/A5-Idle/assets/84187086/25547c7e-b8e0-4647-8eb8-26a0c8324472">
