### PR TITLE
[FE] 이미지 최적화 시도

### DIFF
--- a/frontend/Idle/src/App.jsx
+++ b/frontend/Idle/src/App.jsx
@@ -1,19 +1,23 @@
 import { ThemeProvider } from "styled-components";
 import color from "./styles/theme";
 import { Reset } from "styles/globalStyle";
-import { useReducer } from "react";
-import { carContext } from "utils/context";
+import { useReducer, useState } from "react";
+import { carContext, preloadContext } from "utils/context";
 import { globalCar } from "utils/globalCar";
 import Router from "utils/router";
 import { carReducer } from "utils/reducer";
 
 function App() {
   const [car, dispatch] = useReducer(carReducer, globalCar);
+  const [preLoadData, setPreLoadData] = useState([])
+  const [loaderIdx, setLoaderIdx] = useState(0)
   return (
     <ThemeProvider theme={color}>
       <Reset />
       <carContext.Provider value={{ car, dispatch }}>
-        <Router />
+        <preloadContext.Provider value={{ preLoadData, setPreLoadData, loaderIdx, setLoaderIdx }}>
+          <Router />
+        </preloadContext.Provider>
       </carContext.Provider>
     </ThemeProvider>
   );

--- a/frontend/Idle/src/components/common/buttons/BlueButton.jsx
+++ b/frontend/Idle/src/components/common/buttons/BlueButton.jsx
@@ -8,9 +8,9 @@ import palette from "styles/palette";
  * @param {boolean} isActive 비/활성화상태 (default : true)
  * @returns 버튼
  */
-function BlueButton({ text, onClick, isActive = true }) {
+function BlueButton({ text, onClick, onMouseEnter, isActive = true }) {
   return (
-    <StButton $isActive={isActive} onClick={onClick}>
+    <StButton $isActive={isActive} onClick={onClick} onMouseEnter={onMouseEnter}>
       {text}
     </StButton>
   );

--- a/frontend/Idle/src/components/common/buttons/WhiteButton.jsx
+++ b/frontend/Idle/src/components/common/buttons/WhiteButton.jsx
@@ -8,9 +8,9 @@ import palette from "styles/palette";
  * @param {boolean} isActive 비/활성화상태 (default : true)
  * @returns 버튼
  */
-function WhiteButton({ text, onClick, isActive = true }) {
+function WhiteButton({ text, onClick, onMouseEnter, isActive = true }) {
   return (
-    <StButton $isActive={isActive} onClick={onClick}>
+    <StButton $isActive={isActive} onClick={onClick} onMouseEnter={onMouseEnter}>
       {text}
     </StButton>
   );

--- a/frontend/Idle/src/components/common/content/Car3D.jsx
+++ b/frontend/Idle/src/components/common/content/Car3D.jsx
@@ -1,19 +1,6 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { styled } from "styled-components";
 import palette from "styles/palette";
-
-function preloadImage(src = null) {
-  return new Promise((resolve, reject) => {
-    const img = new Image()
-    img.onload = function () {
-      resolve(img)
-    }
-    img.onerror = img.onabort = function () {
-      reject(src)
-    }
-    img.src = src
-  })
-}
 
 function Car3D({ data = null }) {
   const [currentImg, setCurrentImage] = useState(0);
@@ -21,9 +8,6 @@ function Car3D({ data = null }) {
   const [beforeX, setBeforeX] = useState(0);
   let imgCount = data === null ? 0 : data[0]?.carImgUrls.length - 1;
 
-  useEffect(() => {
-    data === null ? "" : data[0]?.carImgUrls?.map((item) => { preloadImage(item.imgUrl) })
-  }, [data])
   function turnLeft() {
     if (currentImg === imgCount) {
       setCurrentImage(0);
@@ -40,11 +24,10 @@ function Car3D({ data = null }) {
   }
   function turnCar(e) {
     if (isMouseDown && e.clientX != beforeX) {
-      console.log(e.clientX - beforeX);
-      if (e.clientX - beforeX > 1) {
+      if (e.clientX - beforeX > 2) {
         turnRight()
         setBeforeX(e.clientX);
-      } else if (beforeX - e.clientX > 1) {
+      } else if (beforeX - e.clientX > 2) {
         turnLeft()
         setBeforeX(e.clientX);
       }

--- a/frontend/Idle/src/components/findTrim/FindTrimButton.jsx
+++ b/frontend/Idle/src/components/findTrim/FindTrimButton.jsx
@@ -2,11 +2,11 @@ import styled from "styled-components";
 import { ReactComponent as ArrowUpper } from "images/arrowUpper.svg";
 import palette from "styles/palette";
 
-function FindTrimButton({ onClick }) {
+function FindTrimButton({ onClick, onMouseEnter }) {
   return (
     <StFindTrimButton onClick={onClick}>
       <StArrowContainer />
-      <StFindTrimButtonText>내게 맞는 트림 찾기</StFindTrimButtonText>
+      <StFindTrimButtonText onMouseEnter={onMouseEnter}>내게 맞는 트림 찾기</StFindTrimButtonText>
     </StFindTrimButton>
   );
 }

--- a/frontend/Idle/src/components/findTrim/Modal.jsx
+++ b/frontend/Idle/src/components/findTrim/Modal.jsx
@@ -20,7 +20,7 @@ import { PATH } from "utils/constants";
 import { optionPostAPI, submitPostAPI } from "../../utils/api";
 import { PUSH_OPTION_ALERT } from "../../utils/actionType";
 
-function Modal({ setVisible }) {
+function Modal({ setVisible, onMouseEnter }) {
   const { dispatch } = useContext(carContext);
   const [state, stateDispatch] = useReducer(findTrimReducer, findTrimInitialState);
 
@@ -83,9 +83,9 @@ function Modal({ setVisible }) {
               text={"나가기"}
               onClick={() => {
                 clickExit(1000);
-              }}
+              }} onMouseEnter={onMouseEnter}
             />
-            <BlueButton text={"확인"} isActive={state.clickActive} onClick={clickCheck} />
+            <BlueButton text={"확인"} isActive={state.clickActive} onClick={clickCheck} onMouseEnter={onMouseEnter} />
           </StFindTrimContentButtonContainer>
         </StFindTrimContentContainer>
         {state.showOptionAlert && <OptionAlert text={state.optionAlert} />}

--- a/frontend/Idle/src/components/findTrim/index.jsx
+++ b/frontend/Idle/src/components/findTrim/index.jsx
@@ -2,7 +2,7 @@ import FindTrimButton from "./FindTrimButton";
 import Modal from "./Modal";
 import { useState } from "react";
 
-function FindTrim({ onClick }) {
+function FindTrim({ onClick, onMouseEnter }) {
   function findButtonClicked() {
     onClick(false);
     setModalVisible(true);
@@ -11,10 +11,10 @@ function FindTrim({ onClick }) {
   return (
     <>
       {modalVisible ? (
-        <Modal setVisible={setModalVisible} />
+        <Modal setVisible={setModalVisible} onMouseEnter={onMouseEnter} />
       ) : (<> </>
       )}
-      <FindTrimButton onClick={findButtonClicked} />
+      <FindTrimButton onClick={findButtonClicked} onMouseEnter={onMouseEnter} />
     </>
   );
 }

--- a/frontend/Idle/src/components/trimMain/index.jsx
+++ b/frontend/Idle/src/components/trimMain/index.jsx
@@ -4,10 +4,10 @@ import { carContext } from "../../utils/context"
 import ExteriorBoxContainer from "./ExteriorBoxContainer";
 import InteriorBoxContainer from "./InteriorBoxContainer";
 
-function TrimMain(data) {
+function TrimMain({ data, onMouseEnter }) {
     const { car } = useContext(carContext)
     const dots = useRef([]);
-    const filteredData = data?.data?.filter((item) => item.name === car.trim.name);
+    const filteredData = data?.filter((item) => item.name === car.trim.name);
     return (
         <StContainer>
             <StTitleContainer>
@@ -26,7 +26,7 @@ function TrimMain(data) {
             {filteredData ? <StImage id={"here"} src={filteredData[0]?.imgUrl}></StImage> : <p>Loading...</p>}
             <DotContainer >
                 {filteredData[0].thumbnailFunctions.map((item, idx) => (
-                    <Dot1 key={idx} $y={item.heightPixel} $x={item.widthPixel} ref={elem => (dots.current[idx] = elem)} >
+                    <Dot1 onMouseEnter={onMouseEnter} key={idx} $y={item.heightPixel} $x={item.widthPixel} ref={elem => (dots.current[idx] = elem)} >
                         <InnerDots />
                         <OptionToolTip className="tooltip">{item.name}</OptionToolTip>
                     </Dot1>

--- a/frontend/Idle/src/pages/colorPage.jsx
+++ b/frontend/Idle/src/pages/colorPage.jsx
@@ -58,6 +58,7 @@ function ColorPage() {
     getAPI(PATH.COLOR.EXTERIOR, { trimId: car.trim.trimId }).then((result) => {
       setExteriorData(result);
       cachedExterior = result;
+      console.log(result);
       dispatch({ type: SET_CAR_IMG, payload: result[0].carImgUrls[0].imgUrl });
     });
   }, []);

--- a/frontend/Idle/src/pages/detailModelPage.jsx
+++ b/frontend/Idle/src/pages/detailModelPage.jsx
@@ -28,7 +28,6 @@ function DetailModelPage() {
   const [currentTab, setCurrentTab] = useState(tab);
   const { car, dispatch } = useContext(carContext);
   const [detailData, setDetailData] = useState(cachedData);
-
   const [warningModalVisible, setWarningModalVisible] = useState(false);
   const [optionsToBeRemoved, setOptionsToBeRemoved] = useState([]);
 

--- a/frontend/Idle/src/pages/mainPage.jsx
+++ b/frontend/Idle/src/pages/mainPage.jsx
@@ -2,11 +2,35 @@ import { styled } from "styled-components";
 import hyundaiVideo from "images/palisadeVideo.mp4";
 import MainLogoWhite from "logos/MainLogoWhite";
 import { useNavigate } from "react-router-dom";
-import { setClickedOptionPage } from "../utils/constants";
+import { PATH, setClickedOptionPage } from "../utils/constants";
+import { useEffect } from "react";
+import { getAPI } from "../utils/api";
+
+function preloadImage(src = null) {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    img.onload = function () {
+      resolve(img)
+    }
+    img.onerror = img.onabort = function () {
+      reject(src)
+    }
+    img.src = src
+  })
+}
+function preloadImages(srcs) {
+  return Promise.all(srcs.map((item) => { preloadImage(item.imgUrl); }));
+}
 
 function MainPage() {
   const navigate = useNavigate();
   setClickedOptionPage(false);
+  useEffect(() => {
+    getAPI(PATH.COLOR.EXTERIOR, { trimId: 4 }).then((result) => {
+      result.map((item) => { preloadImages(item.carImgUrls) })
+    });
+  }, []);
+
   return (
     <>
       <StLogo>

--- a/frontend/Idle/src/pages/mainPage.jsx
+++ b/frontend/Idle/src/pages/mainPage.jsx
@@ -2,34 +2,11 @@ import { styled } from "styled-components";
 import hyundaiVideo from "images/palisadeVideo.mp4";
 import MainLogoWhite from "logos/MainLogoWhite";
 import { useNavigate } from "react-router-dom";
-import { PATH, setClickedOptionPage } from "../utils/constants";
-import { useEffect } from "react";
-import { getAPI } from "../utils/api";
-
-function preloadImage(src = null) {
-  return new Promise((resolve, reject) => {
-    const img = new Image()
-    img.onload = function () {
-      resolve(img)
-    }
-    img.onerror = img.onabort = function () {
-      reject(src)
-    }
-    img.src = src
-  })
-}
-function preloadImages(srcs) {
-  return Promise.all(srcs.map((item) => { preloadImage(item.imgUrl); }));
-}
+import { setClickedOptionPage } from "../utils/constants";
 
 function MainPage() {
   const navigate = useNavigate();
   setClickedOptionPage(false);
-  useEffect(() => {
-    getAPI(PATH.COLOR.EXTERIOR, { trimId: 4 }).then((result) => {
-      result.map((item) => { preloadImages(item.carImgUrls) })
-    });
-  }, []);
 
   return (
     <>

--- a/frontend/Idle/src/pages/trimPage.jsx
+++ b/frontend/Idle/src/pages/trimPage.jsx
@@ -37,8 +37,8 @@ function TrimPage() {
   }, []);
 
   function handleMouseEnter() {
-    if (loaderIdx < preLoadData.length) {
-      preLoadData[loaderIdx].map((item) => preloadImage(item.imgUrl))
+    if ((loaderIdx / 2) < preLoadData.length) {
+      preLoadData[Math.floor(loaderIdx / 2)].map((item, idx) => { idx % 2 === (loaderIdx % 2) && preloadImage(item.imgUrl) })
       setLoaderIdx((prev) => prev + 1)
     }
   }

--- a/frontend/Idle/src/utils/context.jsx
+++ b/frontend/Idle/src/utils/context.jsx
@@ -4,3 +4,4 @@ export const carContext = createContext();
 export const selectedOptionContext = createContext();
 export const stateContext = createContext();
 export const dispatchContext = createContext();
+export const preloadContext = createContext();

--- a/frontend/Idle/src/utils/preloader.jsx
+++ b/frontend/Idle/src/utils/preloader.jsx
@@ -1,0 +1,12 @@
+export function preloadImage(src = null) {
+    return new Promise((resolve, reject) => {
+        const img = new Image()
+        img.onload = function () {
+            resolve(img)
+        }
+        img.onerror = img.onabort = function () {
+            reject(src)
+        }
+        img.src = src
+    })
+}


### PR DESCRIPTION
## 🚩 관련 이슈
- close #296 

## 📋 구현 기능 명세
- [x] 이미지 프리로딩
- [x] 이미지 데이터 context 저장 시도

## 📌 PR Point
- 처음에는 이미지 프리로딩을 420장을 메인 영상나오는 페이지에서 전부 로딩하고 시작하려 했으나 개발자적인 관점에서 생각했을때는 옳지 않은 방법이라 생각하여 일단 트림 선택 페이지에서 특정 버튼들에 마우스 호버시 30장씩 프리로딩하도록 구현하였다.
- 420장을 30장씩 하기때문에 14번의 프리로딩이 필요한데 프리로딩 강도와 빈도에 대해 토의가 필요할 것 같다

## 📸 결과물 스크린샷
트림 위의 기능 표시 점, 내게 맞는 트림찾기 버튼, 트림찾기 보달에서 닫기, 확인 버튼, 다음 버튼을 호버시에 30장씩 프리로딩
![ezgif com-video-to-gif (7)](https://github.com/softeerbootcamp-2nd/A5-Idle/assets/39405559/94b5f342-a758-4947-9779-73a4fbdf6205)

영상에서 초기 로딩이 느린거는 제 맥북이 지금 불나고 있어서 쓰로틀링 걸린거 같아요,,,ㅠㅠ
