### PR TITLE
[FE] 옵션 박스 disable 기능 구현 

### DIFF
--- a/frontend/Idle/src/components/common/boxs/OptionBox.jsx
+++ b/frontend/Idle/src/components/common/boxs/OptionBox.jsx
@@ -14,6 +14,7 @@ import { ADD, CONFUSE, NONE } from "utils/constants";
 
 function OptionBox({
   optionId,
+  optionCanSelect,
   optionName,
   optionPrice,
   optionPurchaseRate,
@@ -72,6 +73,7 @@ function OptionBox({
         onClick={() => setSelectedOption(optionName)}
         $isSelected={isSelected}
         $state={state}
+        $optionCanSelect={optionCanSelect}
       >
         <ClickedBorder $isSelected={isSelected} $state={state} />
         <StContent>
@@ -143,6 +145,8 @@ const StContainer = styled.div`
   flex-shrink: 0;
   pointer-events: ${({ $state }) => ($state === "block" ? NONE : "")};
   opacity: ${({ $state }) => ($state ? 1 : 0.2)};
+  pointer-events: ${({ $optionCanSelect }) => ($optionCanSelect ? "" : "none")};
+  opacity: ${({ $optionCanSelect }) => ($optionCanSelect ? 1 : 0.2)};
   &:hover {
     background: ${({ $state }) => {
     switch ($state) {
@@ -156,7 +160,7 @@ const StContainer = styled.div`
   }};
     opacity: 0.9;
     cursor: pointer;
-  }
+  };
 `;
 
 const StContent = styled.div`

--- a/frontend/Idle/src/components/defaultOption/Modal.jsx
+++ b/frontend/Idle/src/components/defaultOption/Modal.jsx
@@ -1,5 +1,5 @@
 import { styled, keyframes } from "styled-components";
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import CloseButton from "./CloseButton";
 import CategoryTabs from "tabs/CategoryTabs";
 import ItemBox from "./ItemBox";
@@ -8,6 +8,7 @@ import { createPortal } from "react-dom";
 import palette from "styles/palette";
 import { getAPI } from "utils/api";
 import { PATH } from "utils/constants";
+import { carContext } from "../../utils/context"
 
 function Modal({ setVisible }) {
   const pageSize = 10;
@@ -15,6 +16,7 @@ function Modal({ setVisible }) {
   const [data, setData] = useState([]);
   const [currentTab, setCurrentTab] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
+  const { car } = useContext(carContext);
 
   useEffect(() => {
     setCurrentPage(1);
@@ -22,7 +24,7 @@ function Modal({ setVisible }) {
 
   useEffect(() => {
     async function fetchGet() {
-      const result = await getAPI(PATH.OPTION.DEFAULT, { trimId: 1 });
+      const result = await getAPI(PATH.OPTION.DEFAULT, { trimId: car.trim.trimId });
       setData(result);
       setCurrentTab(result[0].categoryName);
     }

--- a/frontend/Idle/src/pages/colorPage.jsx
+++ b/frontend/Idle/src/pages/colorPage.jsx
@@ -58,7 +58,6 @@ function ColorPage() {
     getAPI(PATH.COLOR.EXTERIOR, { trimId: car.trim.trimId }).then((result) => {
       setExteriorData(result);
       cachedExterior = result;
-      console.log(result);
       dispatch({ type: SET_CAR_IMG, payload: result[0].carImgUrls[0].imgUrl });
     });
   }, []);

--- a/frontend/Idle/src/pages/optionPage.jsx
+++ b/frontend/Idle/src/pages/optionPage.jsx
@@ -96,7 +96,6 @@ function OptionPage() {
         if (res === cachedOptionData) return
         setData(res);
         cachedOptionData = res;
-        console.log(res);
       });
     }
     fetchData();

--- a/frontend/Idle/src/pages/optionPage.jsx
+++ b/frontend/Idle/src/pages/optionPage.jsx
@@ -1,5 +1,5 @@
 import DefaultOption from "defaultOption/index";
-import { useEffect, useRef, useState, useContext, useLayoutEffect } from "react";
+import { useRef, useState, useContext, useLayoutEffect } from "react";
 import OptionBox from "boxs/OptionBox";
 import {
   ALL,
@@ -60,6 +60,7 @@ function OptionPage() {
   const tabs = [ALL, SAFETY, STYLE, PROTECTION, CONVENIENCE];
   const scrollBar = useRef();
   const navigate = useNavigate();
+  let selectedOptionIds = []
 
   useLayoutEffect(() => {
     if (!scrollBar.current) {
@@ -83,19 +84,23 @@ function OptionPage() {
   }, [scrollBar.current]);
 
   useLayoutEffect(() => {
+    selectedOptionIds = []
+    car.option.additional.map((item) => selectedOptionIds.push(item.optionId))
+    car.option.confusing.map((item) => selectedOptionIds.push(item.optionId))
     async function fetchData() {
       await submitPostAPI(PATH.OPTION.GET, {
         trimId: car.trim.trimId,
-        selectedOptionIds: [],
+        selectedOptionIds: selectedOptionIds,
         engineId: car.detail.engines.id,
       }).then((res) => {
         if (res === cachedOptionData) return
         setData(res);
         cachedOptionData = res;
+        console.log(res);
       });
     }
     fetchData();
-  }, []);
+  }, [car.option]);
 
   useLayoutEffect(() => {
     setFilteredData(filterData(data, currentTab));


### PR DESCRIPTION
## 🚩 관련 이슈
- close #298 

## 📋 구현 기능 명세
- [x]  기능 추가하기나 고민해보기 기능 사용시 api 재통신
- [x]  disable 되는 박스 재렌더링 

## 📌 PR Point
-  api 통신하는 useLayoutEffect에 car.option을 참조하도록 수정하고 api를 재통신 한다.
- optionCanSelect의 조건을 optionBox에서 prop으로 클릭 여부를 체크한다.

## 📸 결과물 스크린샷
<img width="912" alt="스크린샷 2023-08-21 오전 11 02 04" src="https://github.com/softeerbootcamp-2nd/A5-Idle/assets/39405559/9d943b7a-50e0-4a59-8082-f17deebc0617">

