### PR TITLE
[BE] 추가 옵션 선택 시 활성화, 비활성화 정보 필드 타입 수정

### DIFF
--- a/backend/src/main/java/com/autoever/idle/domain/option/dto/OptionDto.java
+++ b/backend/src/main/java/com/autoever/idle/domain/option/dto/OptionDto.java
@@ -5,8 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Getter
 @Setter
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OptionDto {
     private Long optionId;
@@ -15,9 +15,9 @@ public class OptionDto {
     private String optionPurchaseRate;
     private String optionDescription;
     private String optionCategory;
-    private String optionCanSelect = "true";
+    private boolean optionCanSelect = true;
 
-    public OptionDto(Long optionId, String optionName, Long optionPrice, String optionPurchaseRate, String optionDescription, String optionCategory, String optionCanSelect) {
+    public OptionDto(Long optionId, String optionName, Long optionPrice, String optionPurchaseRate, String optionDescription, String optionCategory, boolean optionCanSelect) {
         this.optionId = optionId;
         this.optionName = optionName;
         this.optionPrice = optionPrice;

--- a/backend/src/main/java/com/autoever/idle/domain/option/dto/OptionFunctionsResponse.java
+++ b/backend/src/main/java/com/autoever/idle/domain/option/dto/OptionFunctionsResponse.java
@@ -18,12 +18,12 @@ public class OptionFunctionsResponse {
     private String optionPurchaseRate;
     private String optionDescription;
     private String optionCategory;
-    private String optionCanSelect = "true";
+    private boolean optionCanSelect = true;
     private List<FunctionDto> functions;
 
     public OptionFunctionsResponse(Long optionId, String optionName, Long optionPrice,
                                    String optionPurchaseRate, String optionDescription,
-                                   String optionCategory, String optionCanSelect, List<FunctionDto> functions) {
+                                   String optionCategory, boolean optionCanSelect, List<FunctionDto> functions) {
         this.optionId = optionId;
         this.optionName = optionName;
         this.optionPrice = optionPrice;
@@ -42,7 +42,7 @@ public class OptionFunctionsResponse {
                 optionDto.getOptionPurchaseRate(),
                 optionDto.getOptionDescription(),
                 optionDto.getOptionCategory(),
-                optionDto.getOptionCanSelect(),
+                optionDto.isOptionCanSelect(),
                 functions
         );
     }

--- a/backend/src/main/java/com/autoever/idle/domain/option/service/OptionService.java
+++ b/backend/src/main/java/com/autoever/idle/domain/option/service/OptionService.java
@@ -25,7 +25,7 @@ public class OptionService {
 
         for (OptionDto optionDto : additionalOptionList) {
             if (notActivatedOptionIdList.contains(optionDto.getOptionId())) {
-                optionDto.setOptionCanSelect("false");
+                optionDto.setOptionCanSelect(false);
             }
             optionFunctionsResponseList.add(OptionFunctionsResponse.create(
                     optionDto,

--- a/backend/src/test/java/com/autoever/idle/domain/option/OptionControllerTest.java
+++ b/backend/src/test/java/com/autoever/idle/domain/option/OptionControllerTest.java
@@ -64,7 +64,7 @@ class OptionControllerTest {
                 "구매자 10%가 선택",
                 "흠집없이 내 차에 짐을 싣고 싶다면?\n프로텍션 매트 패기지1로 흠집 걱정 없이 짐을 실어보세요.",
                 "차량 보호",
-                "false",
+                false,
                 functionDtoList
         );
         optionFunctionsResponseList.add(optionFunctionsResponse);

--- a/backend/src/test/java/com/autoever/idle/domain/option/OptionServiceTest.java
+++ b/backend/src/test/java/com/autoever/idle/domain/option/OptionServiceTest.java
@@ -64,7 +64,7 @@ class OptionServiceTest {
                 "구매자 10%가 선택",
                 "흠집없이 내 차에 짐을 싣고 싶다면?\n프로텍션 매트 패기지1로 흠집 걱정 없이 짐을 실어보세요.",
                 "차량 보호",
-                "false");
+                false);
 
         OptionDto optionDto2 = new OptionDto(7L,
                 "차량 보호 필름",
@@ -72,7 +72,7 @@ class OptionServiceTest {
                 "구매자 30%가 선택",
                 "흠집으로 부터 차량을 보호하고 싶다면?\n차량 보호 필름을 통해 내 차를 지켜보세요.",
                 "차량 보호",
-                "true");
+                true);
 
         OptionDto optionDto3 = new OptionDto(
                 13L,
@@ -81,7 +81,7 @@ class OptionServiceTest {
                 "구매자 60%가 선택",
                 "현대자동차의 기술력과 노하우가 결합된 커스터마이징 브랜드 N 퍼포먼스의 알콘(alcon)단조 브레이크 & 20인치 휠 패키지",
                 "스타일&퍼포먼스",
-                "true"
+                true
         );
 
         additionalOptionListSortedByPrice.add(optionDto1);


### PR DESCRIPTION
## 🚩 관련 이슈
- close #302 

## 📋 구현 기능 명세
추가 옵션 선택 시 활성화 비활성화 판단 여부 boolean으로 반환하도록 변경

## ✅ Tasks
- [x] optionCanSelect 필드 boolean 으로 변경
- [x] 필드 변경에 따른 테스트 코드 수정 

## 📌 PR Point
- JSON 형식에서 boolean을 받을 수 있는지 몰랐다...

## 📸 결과물 스크린샷
![image](https://github.com/softeerbootcamp-2nd/A5-Idle/assets/109746210/30e0335b-747c-40b8-b8d6-d52e5bfc247b)

