### PR TITLE
[FE] 견적완성 페이지 밑에 부분 구현 

### DIFF
--- a/frontend/Idle/src/components/BillMain/BillDetail.jsx
+++ b/frontend/Idle/src/components/BillMain/BillDetail.jsx
@@ -58,7 +58,7 @@ function BillDetail({ item, data }) {
         ) : (
           <></>
         )}
-        <p>{price ? price.toLocaleString() : "0"} 원</p>
+        <p>+{price ? price.toLocaleString() : "0"} 원</p>
       </StDetailContainer>
     </StContainer>
   );

--- a/frontend/Idle/src/components/BillMain/BillMain.jsx
+++ b/frontend/Idle/src/components/BillMain/BillMain.jsx
@@ -5,6 +5,7 @@ import palette from "styles/palette";
 import BillOptionContainer from "billMain/BillOptionContainer";
 import { useContext } from "react";
 import { carContext } from "utils/context";
+import LocationButton from "buttons/LocationButton";
 
 function BillMain({ data }) {
   const { car } = useContext(carContext);
@@ -25,6 +26,40 @@ function BillMain({ data }) {
         confused={car.option.confusing}
         data={data}
       />
+      <StDelivery>
+        <StContentTitle>
+          탁송
+          <StPrice>+0 원</StPrice>
+        </StContentTitle>
+        <StDeliveryContent>
+          <StDeliveryContentBox>
+            탁송 지역
+            <LocationButton location={"서울"} />
+            <LocationButton location={"서울특별시"} />
+          </StDeliveryContentBox>
+        </StDeliveryContent>
+      </StDelivery>
+      <StHr />
+      <StSale>
+        <StSaleTitle>할인/포인트</StSaleTitle>
+        <StSaleContent>
+          <StBtn>{"할인/포인트 선택하기"}</StBtn>
+          <StSaleDescription>
+            할인 및 사용 가능한 포인트를 입력하고 차량의 할인 금액을 확인해 보세요. <br />
+            개별소비세 감면 혜택도 할인/포인트를 선택하시면 적용됩니다.
+          </StSaleDescription>
+        </StSaleContent>
+      </StSale>
+      <StHr />
+      <StSale>
+        <StSaleTitle>결제 방법</StSaleTitle>
+        <StSaleContent>
+          <StBtn>{"결제수단 선택하기"}</StBtn>
+          <StSaleDescription>
+            결제수단을 선택하고 지불조건 및 납입사항을 확인하세요.
+          </StSaleDescription>
+        </StSaleContent>
+      </StSale>
     </StContainer>
   );
 }
@@ -77,4 +112,124 @@ const AnimationContainer = styled.div`
     opacity: 1;
   }
   `} ${({ $duration }) => `${$duration / 3 + 0.5}s`} ease;
-`
+`;
+
+const StDelivery = styled.div`
+  display: flex;
+  flex-direction: column;
+  color: ${palette.Black};
+  width: 830px;
+`;
+
+const StSale = styled.div`
+  display: flex;
+  flex-direction: column;
+  color: ${palette.Black};
+  width: 830px;
+  height: 150px;
+  align-items: center;
+`;
+
+const StSaleContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 555px;
+  height: 102px;
+  gap: 30px;
+  align-items: center;
+`;
+
+const StDeliveryContent = styled.div`
+  position: relative;
+  left: 10%;
+  display: flex;
+  width: 676px;
+  height: 92px;
+  align-items: center;
+  gap: 24px;
+  font-family: Hyundai Sans Text KR;
+  font-size: 20px;
+  font-weight: 500;
+  line-height: 28px;
+  letter-spacing: -0.03em;
+`;
+
+const StContentTitle = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 828px;
+  font-family: Hyundai Sans Text KR;
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 28px;
+  letter-spacing: -0.03em;
+  text-align: left;
+  white-space: break-spaces;
+`;
+
+const StDeliveryContentBox = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 676px;
+  height: 56px;
+`;
+
+const StPrice = styled.div`
+  font-family: Hyundai Sans Text KR;
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 28px;
+  letter-spacing: -0.03em;
+  text-align: right;
+`;
+
+const StHr = styled.hr`
+  height: 1px;
+  background-color: ${palette.Grey_3};
+  border: none;
+  margin: 20px 0;
+`;
+
+const StSaleTitle = styled.div`
+  width: auto;
+  font-family: Hyundai Sans Text KR;
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 28px;
+  letter-spacing: -0.03em;
+  text-align: left;
+  white-space: break-spaces;
+  width: 830px;
+  height: 28px;
+  margin-bottom: 24px;
+`;
+
+const StBtn = styled.button`
+  width: auto;
+  height: 36px;
+  padding: 5px 20px;
+  justify-content: center;
+  align-items: center;
+  background-color: #1a3276;
+  color: white;
+  font-family: "Hyundai Sans Text KR";
+  font-size: 13px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 165%;
+  letter-spacing: -0.39px;
+  text-align: center;
+  cursor: pointer;
+`;
+
+const StSaleDescription = styled.div`
+  width: 555px;
+  height: 42px;
+  font-family: Hyundai Sans Text KR;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 21px;
+  letter-spacing: -0.03em;
+  text-align: center;
+`;

--- a/frontend/Idle/src/components/BillMain/BillMain.jsx
+++ b/frontend/Idle/src/components/BillMain/BillMain.jsx
@@ -26,40 +26,42 @@ function BillMain({ data }) {
         confused={car.option.confusing}
         data={data}
       />
-      <StDelivery>
-        <StContentTitle>
-          탁송
-          <StPrice>+0 원</StPrice>
-        </StContentTitle>
-        <StDeliveryContent>
-          <StDeliveryContentBox>
-            탁송 지역
-            <LocationButton location={"서울"} />
-            <LocationButton location={"서울특별시"} />
-          </StDeliveryContentBox>
-        </StDeliveryContent>
-      </StDelivery>
-      <StHr />
-      <StSale>
-        <StSaleTitle>할인/포인트</StSaleTitle>
-        <StSaleContent>
-          <StBtn>{"할인/포인트 선택하기"}</StBtn>
-          <StSaleDescription>
-            할인 및 사용 가능한 포인트를 입력하고 차량의 할인 금액을 확인해 보세요. <br />
-            개별소비세 감면 혜택도 할인/포인트를 선택하시면 적용됩니다.
-          </StSaleDescription>
-        </StSaleContent>
-      </StSale>
-      <StHr />
-      <StSale>
-        <StSaleTitle>결제 방법</StSaleTitle>
-        <StSaleContent>
-          <StBtn>{"결제수단 선택하기"}</StBtn>
-          <StSaleDescription>
-            결제수단을 선택하고 지불조건 및 납입사항을 확인하세요.
-          </StSaleDescription>
-        </StSaleContent>
-      </StSale>
+      <StExtraContainer>
+        <StDelivery>
+          <StContentTitle>
+            탁송
+            <StPrice>+0 원</StPrice>
+          </StContentTitle>
+          <StDeliveryContent>
+            <StDeliveryContentBox>
+              탁송 지역
+              <LocationButton location={"서울"} />
+              <LocationButton location={"서울특별시"} />
+            </StDeliveryContentBox>
+          </StDeliveryContent>
+        </StDelivery>
+        <StHr />
+        <StSale>
+          <StSaleTitle>할인/포인트</StSaleTitle>
+          <StSaleContent>
+            <StBtn>{"할인/포인트 선택하기"}</StBtn>
+            <StSaleDescription>
+              할인 및 사용 가능한 포인트를 입력하고 차량의 할인 금액을 확인해 보세요. <br />
+              개별소비세 감면 혜택도 할인/포인트를 선택하시면 적용됩니다.
+            </StSaleDescription>
+          </StSaleContent>
+        </StSale>
+        <StHr />
+        <StSale>
+          <StSaleTitle>결제 방법</StSaleTitle>
+          <StSaleContent>
+            <StBtn>{"결제수단 선택하기"}</StBtn>
+            <StSaleDescription>
+              결제수단을 선택하고 지불조건 및 납입사항을 확인하세요.
+            </StSaleDescription>
+          </StSaleContent>
+        </StSale>
+      </StExtraContainer>
     </StContainer>
   );
 }
@@ -232,4 +234,22 @@ const StSaleDescription = styled.div`
   line-height: 21px;
   letter-spacing: -0.03em;
   text-align: center;
+`;
+
+const StExtraContainer = styled.div`
+  animation: ${keyframes`
+  0% {
+    transform: translateX(20%);
+    opacity: 0;
+  }
+  50%{
+    transform: translateX(20%);
+    opacity: 0;
+  }
+  100% {
+    transform: translateX(0);
+    
+    opacity: 1;
+  }
+  `} 1s ease;
 `;

--- a/frontend/Idle/src/components/BillMain/BillOptionContainer.jsx
+++ b/frontend/Idle/src/components/BillMain/BillOptionContainer.jsx
@@ -56,6 +56,7 @@ function BillOptionContainer({ added, confused, data }) {
           </StBlock>
         </div>
       </StMain>
+      <hr />
       {isOpen ? (
         <TrimDetailModal
           trim={car.trim.name}

--- a/frontend/Idle/src/components/BillMain/MapModal.jsx
+++ b/frontend/Idle/src/components/BillMain/MapModal.jsx
@@ -259,7 +259,7 @@ const ModalContainer = styled.div`
   left: 50%;
   top: 0;
   left: 0;
-  width: 1280px;
+  width: 100%;
   height: 100%;
   display: flex;
   align-items: center;

--- a/frontend/Idle/src/components/common/buttons/LocationButton.jsx
+++ b/frontend/Idle/src/components/common/buttons/LocationButton.jsx
@@ -1,0 +1,31 @@
+import { styled } from "styled-components";
+import palette from "styles/palette";
+import { ReactComponent as ArrowDown } from "images/arrowDown.svg";
+
+function LocationButton({ location }) {
+  return (
+    <StLocationContainer>
+      {location}
+      <ArrowDown />
+    </StLocationContainer>
+  );
+}
+
+export default LocationButton;
+
+const StLocationContainer = styled.div`
+  display: flex;
+  width: 185px;
+  height: 25px;
+  padding: 8px 16px 8px 16px;
+  background-color: ${palette.Grey_1};
+  font-family: Hyundai Sans Text KR;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 24px;
+  letter-spacing: -0.03em;
+  font-weight: 600;
+  text-align: left;
+  align-items: center;
+  justify-content: space-between;
+`;

--- a/frontend/Idle/src/components/common/buttons/LocationButton.jsx
+++ b/frontend/Idle/src/components/common/buttons/LocationButton.jsx
@@ -28,4 +28,5 @@ const StLocationContainer = styled.div`
   text-align: left;
   align-items: center;
   justify-content: space-between;
+  cursor: pointer;
 `;

--- a/frontend/Idle/src/components/common/modals/OptionModal.jsx
+++ b/frontend/Idle/src/components/common/modals/OptionModal.jsx
@@ -15,17 +15,17 @@ function OptionModal({ data, setModalVisible, setIsSelected, onClick }) {
   function clickClose() {
     setAnimationState(true);
     setTimeout(() => {
-      setModalVisible(false)
+      setModalVisible(false);
     }, 300);
   }
   function selectedBtnClicked() {
     if (state.selectedOption.includes(data.functionId)) {
-      clickClose()
+      clickClose();
       return;
     } else {
       stateDispatch({ type: PUSH_SELECTED_OPTION, payload: data.functionId });
       setIsSelected(true);
-      clickClose()
+      clickClose();
     }
   }
 
@@ -57,15 +57,17 @@ function OptionModal({ data, setModalVisible, setIsSelected, onClick }) {
 }
 export default OptionModal;
 const ModalContainer = styled.div`
-  position: absolute;
+  position: fixed;
+  top: 50%;
+  left: 50%;
   top: 0;
   left: 0;
-  width: 1280px;
+  width: 100%;
   height: 720px;
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 2;  
+  z-index: 2;
 `;
 
 const ModalBackground = styled.div`
@@ -86,7 +88,7 @@ const StContainer = styled.div`
   flex-direction: column;
   align-items: center;
   position: relative;
-  z-index: 3;  
+  z-index: 3;
   transition: opacity 0.5s ease-in-out;
   animation: ${({ $animationstate }) => ($animationstate ? fadeOut : fadeIn)} 0.5s ease;
 `;

--- a/frontend/Idle/src/components/common/modals/RemoveOptionModal.jsx
+++ b/frontend/Idle/src/components/common/modals/RemoveOptionModal.jsx
@@ -146,10 +146,12 @@ const ModalBackground = styled.div`
   backdrop-filter: blur(5px);
 `;
 const ModalContainer = styled.div`
-  position: absolute;
+  position: fixed;
+  top: 50%;
+  left: 50%;
   top: 0;
   left: 0;
-  width: 1280px;
+  width: 100%;
   height: 720px;
   display: flex;
   align-items: center;

--- a/frontend/Idle/src/components/trimDetailModal/TrimDetailModal.jsx
+++ b/frontend/Idle/src/components/trimDetailModal/TrimDetailModal.jsx
@@ -26,7 +26,7 @@ function TrimDetailModal({ trim, desc, setModalOff, defaultFunctions, modalPosit
             <Description>{desc}</Description>
           </StHeaderContainer>
           <StOptionContainer>
-            {defaultFunctions.map((item, idx) => (
+            {defaultFunctions?.map((item, idx) => (
               <OptionDropDown key={idx} category={item} optionData={optionData} />
             ))}
           </StOptionContainer>

--- a/frontend/Idle/src/components/trimDetailModal/TrimDetailModal.jsx
+++ b/frontend/Idle/src/components/trimDetailModal/TrimDetailModal.jsx
@@ -40,10 +40,10 @@ function TrimDetailModal({ trim, desc, setModalOff, defaultFunctions, modalPosit
 export default TrimDetailModal;
 
 const ModalContainer = styled.div`
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
-  width: 1280px;
+  width: 100%;
   height: 100%;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## 🚩 관련 이슈
- close #300

## 📋 구현 기능 명세
- [x] 탁송
- [x] 할인/포인트
- [x] 결제방법


## 📌 PR Point
화살표를 지우고 탁송의 돈부분을 재목과 수평으로 위치시켰습니다.

## 📸 결과물 스크린샷

<img width="1060" alt="image" src="https://github.com/softeerbootcamp-2nd/A5-Idle/assets/84187086/ef10566a-8901-4877-8816-c9c90fbe65b0">

