### PR TITLE
[BE] 추가 옵션 선택 API 쿼리 최적화

### DIFF
--- a/backend/src/main/java/com/autoever/idle/domain/option/dto/OptionDto.java
+++ b/backend/src/main/java/com/autoever/idle/domain/option/dto/OptionDto.java
@@ -15,7 +15,7 @@ public class OptionDto {
     private String optionPurchaseRate;
     private String optionDescription;
     private String optionCategory;
-    private boolean optionCanSelect = true;
+    private boolean optionCanSelect;
 
     public OptionDto(Long optionId, String optionName, Long optionPrice, String optionPurchaseRate, String optionDescription, String optionCategory, boolean optionCanSelect) {
         this.optionId = optionId;

--- a/backend/src/main/java/com/autoever/idle/domain/option/repository/OptionRepository.java
+++ b/backend/src/main/java/com/autoever/idle/domain/option/repository/OptionRepository.java
@@ -7,8 +7,6 @@ import java.util.List;
 
 
 public interface OptionRepository {
-    List<OptionDto> findAdditionalOptionList(Long trimId);
-    List<Long> findNotActivatedOptionIdList(Long engineId, List<Long> selectedOptionIdList);
-
+    List<OptionDto> findAdditionalOptionList(Long trimId, Long engineId, List<Long> selectedOptionIds);
     List<SelectedOptionDto> findSelectedOptions(List<Long> optionIdList);
 }

--- a/backend/src/main/java/com/autoever/idle/domain/option/repository/OptionRepositoryImpl.java
+++ b/backend/src/main/java/com/autoever/idle/domain/option/repository/OptionRepositoryImpl.java
@@ -40,7 +40,7 @@ public class OptionRepositoryImpl implements OptionRepository {
                         "JOIN OPTION_CATEGORY oc ON o.option_category_id = oc.option_category_id " +
                         "WHERE tf.trim_id = :trimId AND tf.is_default = 'FALSE' " +
                         "GROUP BY optionId " +
-                        "ORDER BY optionPrice; ";
+                        "ORDER BY optionName; ";
 
         MapSqlParameterSource params = new MapSqlParameterSource();
         params.addValue("trimId", trimId);

--- a/backend/src/main/java/com/autoever/idle/domain/option/repository/OptionRepositoryImpl.java
+++ b/backend/src/main/java/com/autoever/idle/domain/option/repository/OptionRepositoryImpl.java
@@ -5,7 +5,6 @@ import com.autoever.idle.domain.option.dto.SelectedOptionDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.BeanPropertyRowMapper;
 import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.core.SingleColumnRowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -19,40 +18,36 @@ public class OptionRepositoryImpl implements OptionRepository {
     private final NamedParameterJdbcTemplate jdbcTemplate;
 
     @Override
-    public List<OptionDto> findAdditionalOptionList(Long trimId) {
-        String query = "select o.option_id optionId, o.name optionName, o.price optionPrice, o.purchase_rate optionPurchaseRate, " +
-                "o.description optionDescription, oc.name optionCategory " +
-                "from FUNCTIONS f join TRIM_FUNCTION tf on f.function_id = tf.function_id " +
-                "join `OPTION` o on f.option_id = o.option_id " +
-                "join OPTION_CATEGORY oc on o.option_category_id = oc.option_category_id " +
-                "where tf.trim_id = :trimId and tf.is_default = 'FALSE' " +
-                "group by optionId " +
-                "order by optionPrice";
+    public List<OptionDto> findAdditionalOptionList(Long trimId, Long engineId, List<Long> selectedOptionIds) {
+        String query = "SELECT o.option_id optionId, o.name optionName," +
+                "o.price optionPrice, o.purchase_rate optionPurchaseRate, " +
+                "o.description optionDescription, oc.name optionCategory, " +
+                "CASE " +
+                "    WHEN NOT EXISTS (SELECT 1 FROM OPTION_STATUS os WHERE ";
+        if (selectedOptionIds.isEmpty()) {
+            query += "os.selected_engine_id = :engineId AND os.not_activated_option_id = o.option_id) ";
+        } else {
+            query += "(os.selected_engine_id = :engineId OR os.selected_option_id IN (:selectedOptionIds)) AND os.not_activated_option_id = o.option_id) ";
+        }
+
+        query +=
+                "    THEN 'false' " +
+                        "    ELSE 'true' " +
+                        "END AS optionCanSelect " +
+                        "FROM FUNCTIONS f " +
+                        "JOIN TRIM_FUNCTION tf ON f.function_id = tf.function_id " +
+                        "JOIN `OPTION` o ON f.option_id = o.option_id " +
+                        "JOIN OPTION_CATEGORY oc ON o.option_category_id = oc.option_category_id " +
+                        "WHERE tf.trim_id = :trimId AND tf.is_default = 'FALSE' " +
+                        "GROUP BY optionId " +
+                        "ORDER BY optionPrice; ";
 
         MapSqlParameterSource params = new MapSqlParameterSource();
         params.addValue("trimId", trimId);
+        params.addValue("engineId", engineId);
+        params.addValue("selectedOptionIds", selectedOptionIds);
 
         RowMapper<OptionDto> rowMapper = new BeanPropertyRowMapper<>(OptionDto.class);
-        return jdbcTemplate.query(query, params, rowMapper);
-    }
-
-    @Override
-    public List<Long> findNotActivatedOptionIdList(Long engineId, List<Long> selectedOptionIdList) {
-        String query;
-        if (selectedOptionIdList.isEmpty()) {
-            query = "SELECT os.not_activated_option_id FROM OPTION_STATUS os " +
-                    "WHERE os.selected_engine_id = :engineId";
-        } else {
-            query = "SELECT os.not_activated_option_id FROM OPTION_STATUS os " +
-                    "WHERE os.selected_engine_id = :engineId OR os.selected_option_id IN (:selectedOptionIdList)";
-        }
-
-        MapSqlParameterSource params = new MapSqlParameterSource();
-        params.addValue("engineId", engineId);
-        params.addValue("selectedOptionIdList", selectedOptionIdList);
-
-        RowMapper<Long> rowMapper = new SingleColumnRowMapper<>(Long.class);
-
         return jdbcTemplate.query(query, params, rowMapper);
     }
 

--- a/backend/src/main/java/com/autoever/idle/domain/option/service/OptionService.java
+++ b/backend/src/main/java/com/autoever/idle/domain/option/service/OptionService.java
@@ -19,14 +19,13 @@ public class OptionService {
     private final FunctionRepository functionRepository;
 
     public List<OptionFunctionsResponse> getOptionFunctions(OptionRequest optionRequest) {
-        List<OptionDto> additionalOptionList = optionRepository.findAdditionalOptionList(optionRequest.getTrimId());
-        List<Long> notActivatedOptionIdList = optionRepository.findNotActivatedOptionIdList(optionRequest.getEngineId(), optionRequest.getSelectedOptionIds());
+        List<OptionDto> additionalOptionList = optionRepository.findAdditionalOptionList(optionRequest.getTrimId(),
+                optionRequest.getEngineId(),
+                optionRequest.getSelectedOptionIds());
+
         List<OptionFunctionsResponse> optionFunctionsResponseList = new ArrayList<>();
 
         for (OptionDto optionDto : additionalOptionList) {
-            if (notActivatedOptionIdList.contains(optionDto.getOptionId())) {
-                optionDto.setOptionCanSelect(false);
-            }
             optionFunctionsResponseList.add(OptionFunctionsResponse.create(
                     optionDto,
                     functionRepository.findFunctionsInAdditionalOption(optionDto.getOptionId()))
@@ -64,14 +63,14 @@ public class OptionService {
     }
 
     private int compareRatesAndNames(OptionFunctionsResponse o1, OptionFunctionsResponse o2) {
-        double rate1 = extractRate(o1.getOptionPurchaseRate());
-        double rate2 = extractRate(o2.getOptionPurchaseRate());
+                double rate1 = extractRate(o1.getOptionPurchaseRate());
+                double rate2 = extractRate(o2.getOptionPurchaseRate());
 
-        if (rate1 == rate2) {
-            return o2.getOptionName().compareTo(o1.getOptionName());
-        }
-        if (rate1 < rate2) {
-            return 1;
+                if (rate1 == rate2) {
+                    return o2.getOptionName().compareTo(o1.getOptionName());
+                }
+                if (rate1 < rate2) {
+                    return 1;
         }
 
         return -1;

--- a/backend/src/main/java/com/autoever/idle/domain/option/service/OptionService.java
+++ b/backend/src/main/java/com/autoever/idle/domain/option/service/OptionService.java
@@ -14,7 +14,6 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class OptionService {
-    private static final String NEW = "NEW";
     private final OptionRepository optionRepository;
     private final FunctionRepository functionRepository;
 
@@ -32,56 +31,6 @@ public class OptionService {
             );
         }
 
-        sortByPurchaseRateAndName(optionFunctionsResponseList);
         return optionFunctionsResponseList;
     }
-
-    private void sortByPurchaseRateAndName(List<OptionFunctionsResponse> optionFunctions) {
-        optionFunctions.sort((o1, o2) -> {
-            if (o1.getOptionPrice().equals(o2.getOptionPrice())) {
-                return sortWhenSameOptionPrice(o1, o2);
-            }
-            if (o1.getOptionPrice() < o2.getOptionPrice()) {
-                return -1;
-            }
-            return 1;
-        });
-    }
-
-    private int sortWhenSameOptionPrice(OptionFunctionsResponse o1, OptionFunctionsResponse o2) {
-        int comparedNewOptions = compareIfNewOptions(o1, o2);
-        if (comparedNewOptions != 0) {
-            return comparedNewOptions;
-        }
-
-        return compareRatesAndNames(o1, o2);
-    }
-
-    private int compareIfNewOptions(OptionFunctionsResponse o1, OptionFunctionsResponse o2) {
-        return o1.getOptionPurchaseRate().equals(NEW) ? -1 :
-                o2.getOptionPurchaseRate().equals(NEW) ? 1 : 0;
-    }
-
-    private int compareRatesAndNames(OptionFunctionsResponse o1, OptionFunctionsResponse o2) {
-                double rate1 = extractRate(o1.getOptionPurchaseRate());
-                double rate2 = extractRate(o2.getOptionPurchaseRate());
-
-                if (rate1 == rate2) {
-                    return o2.getOptionName().compareTo(o1.getOptionName());
-                }
-                if (rate1 < rate2) {
-                    return 1;
-        }
-
-        return -1;
-    }
-
-    private double extractRate(String purchaseRate) {
-        String[] splitRate = purchaseRate.split("%")[0].split(" ");
-        if (splitRate.length > 1) {
-            return Double.parseDouble(splitRate[1]);
-        }
-        return 0;
-    }
-
 }

--- a/backend/src/test/java/com/autoever/idle/domain/option/OptionRepositoryImplTest.java
+++ b/backend/src/test/java/com/autoever/idle/domain/option/OptionRepositoryImplTest.java
@@ -30,27 +30,15 @@ class OptionRepositoryImplTest {
     void findAdditionalOptionList() {
         //given
         Long trimId = 1L;
+        Long engineId = 2L;
+        List<Long> selectedOptionIds = List.of(2L, 14L);
 
         //when
-        List<OptionDto> additionalOptionList = optionRepository.findAdditionalOptionList(trimId);
+        List<OptionDto> additionalOptionList = optionRepository.findAdditionalOptionList(trimId, engineId, selectedOptionIds);
 
         //then
         softAssertions.assertThat(additionalOptionList.size()).isEqualTo(12);
 
-    }
-
-    @Test
-    @DisplayName("엔진 ID와 선택된 옵션 ID 목록을 통해 비활성화된 옵션 정보를 반환한다")
-    void findNotActivatedOptionIdList() {
-        //given
-        Long engineId = 1L;
-        List<Long> selectedOptionIds = List.of(15L);
-
-        //when
-        List<Long> notActivatedOptionIdList = optionRepository.findNotActivatedOptionIdList(engineId, selectedOptionIds);
-
-        //then
-        softAssertions.assertThat(notActivatedOptionIdList.size()).isEqualTo(3);
     }
 
     @Test

--- a/backend/src/test/java/com/autoever/idle/domain/option/OptionServiceTest.java
+++ b/backend/src/test/java/com/autoever/idle/domain/option/OptionServiceTest.java
@@ -42,12 +42,10 @@ class OptionServiceTest {
 
     private List<OptionDto> additionalOptionListSortedByPrice;
     private List<OptionDto> additionalOptionListSortedByPurchaseRate;
-    private List<Long> notActivatedOptionIdList;
     private List<FunctionDto> functionDtoList;
 
     @BeforeEach
     void setUp() {
-        notActivatedOptionIdList = List.of(1L, 15L);
         additionalOptionListSortedByPrice = new ArrayList<>();
         additionalOptionListSortedByPurchaseRate = new ArrayList<>();
         functionDtoList = new ArrayList<>();
@@ -97,8 +95,7 @@ class OptionServiceTest {
         OptionRequest optionRequest = new OptionRequest(1L, List.of(1L, 15L), 1L);
 
         //when
-        when(optionRepository.findAdditionalOptionList(any())).thenReturn(additionalOptionListSortedByPrice);
-        when(optionRepository.findNotActivatedOptionIdList(any(), anyList())).thenReturn(notActivatedOptionIdList);
+        when(optionRepository.findAdditionalOptionList(any(), any(), anyList())).thenReturn(additionalOptionListSortedByPrice);
         when(functionRepository.findFunctionsInAdditionalOption(any())).thenReturn(functionDtoList);
         List<OptionFunctionsResponse> optionFunctions = optionService.getOptionFunctions(optionRequest);
 
@@ -116,8 +113,7 @@ class OptionServiceTest {
         OptionRequest optionRequest = new OptionRequest(1L, List.of(1L, 15L), 1L);
 
         //when
-        when(optionRepository.findAdditionalOptionList(any())).thenReturn(additionalOptionListSortedByPurchaseRate);
-        when(optionRepository.findNotActivatedOptionIdList(any(), anyList())).thenReturn(notActivatedOptionIdList);
+        when(optionRepository.findAdditionalOptionList(any(), any(), anyList())).thenReturn(additionalOptionListSortedByPurchaseRate);
         when(functionRepository.findFunctionsInAdditionalOption(any())).thenReturn(functionDtoList);
         List<OptionFunctionsResponse> optionFunctions = optionService.getOptionFunctions(optionRequest);
 

--- a/backend/src/test/java/com/autoever/idle/domain/option/OptionServiceTest.java
+++ b/backend/src/test/java/com/autoever/idle/domain/option/OptionServiceTest.java
@@ -40,14 +40,12 @@ class OptionServiceTest {
     @InjectSoftAssertions
     private SoftAssertions softAssertions;
 
-    private List<OptionDto> additionalOptionListSortedByPrice;
-    private List<OptionDto> additionalOptionListSortedByPurchaseRate;
+    private List<OptionDto> additionalOptionList;
     private List<FunctionDto> functionDtoList;
 
     @BeforeEach
     void setUp() {
-        additionalOptionListSortedByPrice = new ArrayList<>();
-        additionalOptionListSortedByPurchaseRate = new ArrayList<>();
+        additionalOptionList = new ArrayList<>();
         functionDtoList = new ArrayList<>();
         functionDtoList.add(new FunctionDto(
                 119L,
@@ -56,15 +54,7 @@ class OptionServiceTest {
                 "https://a5idle.s3.ap-northeast-2.amazonaws.com/mycarimages/112-1.jpg",
                 null));
 
-        OptionDto optionDto1 = new OptionDto(8L,
-                "프로텍션 매트 패키지 I",
-                550000L,
-                "구매자 10%가 선택",
-                "흠집없이 내 차에 짐을 싣고 싶다면?\n프로텍션 매트 패기지1로 흠집 걱정 없이 짐을 실어보세요.",
-                "차량 보호",
-                false);
-
-        OptionDto optionDto2 = new OptionDto(7L,
+        OptionDto optionDto1 = new OptionDto(7L,
                 "차량 보호 필름",
                 490000L,
                 "구매자 30%가 선택",
@@ -72,58 +62,35 @@ class OptionServiceTest {
                 "차량 보호",
                 true);
 
-        OptionDto optionDto3 = new OptionDto(
-                13L,
-                "알콘(alcon) 단조 브레이크 &amp; 20인치 휠",
-                490000L,
-                "구매자 60%가 선택",
-                "현대자동차의 기술력과 노하우가 결합된 커스터마이징 브랜드 N 퍼포먼스의 알콘(alcon)단조 브레이크 & 20인치 휠 패키지",
-                "스타일&퍼포먼스",
-                true
-        );
+        OptionDto optionDto2 = new OptionDto(8L,
+                "프로텍션 매트 패키지 I",
+                550000L,
+                "구매자 10%가 선택",
+                "흠집없이 내 차에 짐을 싣고 싶다면?\n프로텍션 매트 패기지1로 흠집 걱정 없이 짐을 실어보세요.",
+                "차량 보호",
+                false);
 
-        additionalOptionListSortedByPrice.add(optionDto1);
-        additionalOptionListSortedByPrice.add(optionDto2);
-        additionalOptionListSortedByPurchaseRate.add(optionDto2);
-        additionalOptionListSortedByPurchaseRate.add(optionDto3);
+
+
+        additionalOptionList.add(optionDto1);
+        additionalOptionList.add(optionDto2);
     }
 
     @Test
-    @DisplayName("추가 옵션 정보는 가격순으로 정렬되고 포함하는 기능 정보 목록을 반환한다")
+    @DisplayName("추가 옵션 정보와 포함하는 기능 정보 목록을 반환한다")
     void getOptionFunctions() {
         //given
         OptionRequest optionRequest = new OptionRequest(1L, List.of(1L, 15L), 1L);
 
         //when
-        when(optionRepository.findAdditionalOptionList(any(), any(), anyList())).thenReturn(additionalOptionListSortedByPrice);
+        when(optionRepository.findAdditionalOptionList(any(), any(), anyList())).thenReturn(additionalOptionList);
         when(functionRepository.findFunctionsInAdditionalOption(any())).thenReturn(functionDtoList);
         List<OptionFunctionsResponse> optionFunctions = optionService.getOptionFunctions(optionRequest);
 
         //then
-        softAssertions.assertThat(optionFunctions.get(0).getOptionId()).isEqualTo(additionalOptionListSortedByPrice.get(1).getOptionId());
-        softAssertions.assertThat(optionFunctions.get(0).getOptionName()).isEqualTo(additionalOptionListSortedByPrice.get(1).getOptionName());
-        softAssertions.assertThat(optionFunctions.get(1).getOptionId()).isEqualTo(additionalOptionListSortedByPrice.get(0).getOptionId());
-        softAssertions.assertThat(optionFunctions.get(1).getOptionName()).isEqualTo(additionalOptionListSortedByPrice.get(0).getOptionName());
+        softAssertions.assertThat(optionFunctions.get(0).getOptionId()).isEqualTo(additionalOptionList.get(0).getOptionId());
+        softAssertions.assertThat(optionFunctions.get(0).getOptionName()).isEqualTo(additionalOptionList.get(0).getOptionName());
+        softAssertions.assertThat(optionFunctions.get(1).getOptionId()).isEqualTo(additionalOptionList.get(1).getOptionId());
+        softAssertions.assertThat(optionFunctions.get(1).getOptionName()).isEqualTo(additionalOptionList.get(1).getOptionName());
     }
-
-    @Test
-    @DisplayName("추가 옵션의 가격이 똑같으면 구매비율 내림차순으로 정렬한다")
-    void getOptionFunctions_SortingByPurchaseRate() {
-        //given
-        OptionRequest optionRequest = new OptionRequest(1L, List.of(1L, 15L), 1L);
-
-        //when
-        when(optionRepository.findAdditionalOptionList(any(), any(), anyList())).thenReturn(additionalOptionListSortedByPurchaseRate);
-        when(functionRepository.findFunctionsInAdditionalOption(any())).thenReturn(functionDtoList);
-        List<OptionFunctionsResponse> optionFunctions = optionService.getOptionFunctions(optionRequest);
-
-        //then
-        softAssertions.assertThat(optionFunctions.get(0).getOptionId()).isEqualTo(additionalOptionListSortedByPurchaseRate.get(1).getOptionId());
-        softAssertions.assertThat(optionFunctions.get(0).getOptionDescription()).isEqualTo(additionalOptionListSortedByPurchaseRate.get(1).getOptionDescription());
-        softAssertions.assertThat(optionFunctions.get(0).getOptionName()).isEqualTo(additionalOptionListSortedByPurchaseRate.get(1).getOptionName());
-        softAssertions.assertThat(optionFunctions.get(1).getOptionId()).isEqualTo(additionalOptionListSortedByPurchaseRate.get(0).getOptionId());
-        softAssertions.assertThat(optionFunctions.get(1).getOptionDescription()).isEqualTo(additionalOptionListSortedByPurchaseRate.get(0).getOptionDescription());
-        softAssertions.assertThat(optionFunctions.get(1).getOptionName()).isEqualTo(additionalOptionListSortedByPurchaseRate.get(0).getOptionName());
-    }
-
 }


### PR DESCRIPTION
## 🚩 관련 이슈
- close #341 

## 📋 구현 기능 명세
- [x] OptionRepositoryImpl 쿼리 최적화
- [x] OptionService 로직 수정
- [x] 테스트 코드 수정

## 📌 PR Point
- 기존에는 추가 옵션 선택 요청 시, db와의 커넥션이 잦았음.
- 트림 id를 통해 추가 옵션 목록을 불러오고, 엔진 id와 선택한 옵션 id 목록을 통해 선택할 수 없는 옵션 목록을 불러와서 추가 옵션 목록 중 하나를 꺼내서 선택 불가능한 옵션 목록에 포함되는지 체크해서 불가능하다면 setter를 통해 일일이 수정해주는 작업을 했었다.
- 현재는 위의 모든 과정을 쿼리 하나로 통합시켰음

## 📸 결과물 스크린샷
![image](https://github.com/softeerbootcamp-2nd/A5-Idle/assets/109746210/29d2b928-139f-4c43-9d41-a73fa0febed6)


