### PR TITLE
[FE] 이미지 태그, 컴포넌트들에 alt속성 추가 

### DIFF
--- a/frontend/Idle/index.html
+++ b/frontend/Idle/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-
+    <meta name="description" content="MyCarMaster" />
     <title>마이 카마스터</title>
     <script
       type="text/javascript"

--- a/frontend/Idle/src/components/billPage/billSub/BillOptionBox.jsx
+++ b/frontend/Idle/src/components/billPage/billSub/BillOptionBox.jsx
@@ -85,7 +85,6 @@ const StImg = styled.img`
 const StContent = styled.div`
   display: flex;
   width: 175px;
-  /* padding: 0px 32px; */
   flex-direction: column;
   justify-content: center;
   align-items: flex-start;

--- a/frontend/Idle/src/components/billPage/billSub/BillOptionBox.jsx
+++ b/frontend/Idle/src/components/billPage/billSub/BillOptionBox.jsx
@@ -39,7 +39,7 @@ function BillOptionBox({ isAdded, data }) {
         }}
       >
         <StImageContainer>
-          <StImg src={data?.optionImgUrl}></StImg>
+          <StImg alt="OptionImg" src={data?.optionImgUrl} />
         </StImageContainer>
         <StContent>
           <StCategory className="optionCategory">{data?.optionCategory}</StCategory>

--- a/frontend/Idle/src/components/billPage/carMaster/CustomOverlay.jsx
+++ b/frontend/Idle/src/components/billPage/carMaster/CustomOverlay.jsx
@@ -40,6 +40,7 @@ function CustomOverlay(data, onClick) {
   const image = document.createElement("img");
   image.src = hyundai;
   image.classList.add("st-img");
+  image.alt = "st-img";
   main.appendChild(image);
 
   const footer = document.createElement("div");

--- a/frontend/Idle/src/components/billPage/carMaster/DealerBox.jsx
+++ b/frontend/Idle/src/components/billPage/carMaster/DealerBox.jsx
@@ -6,7 +6,7 @@ function DealerBox({ data, isSelected, onClick }) {
     <StContainer $isSelected={isSelected} onClick={onClick}>
       <StMainContainer>
         <div>
-          <StImg src={data.masterImgUrl} />
+          <StImg alt="MasterImg" src={data.masterImgUrl} />
         </div>
         <StSubContainer>
           <StName>{data.masterName}</StName>
@@ -35,7 +35,7 @@ const StContainer = styled.div`
 
   &:hover {
     background-color: ${({ $isSelected }) =>
-    $isSelected ? `${palette.NavyBlue_5}` : `${palette.NavyBlue_1}`};
+      $isSelected ? `${palette.NavyBlue_5}` : `${palette.NavyBlue_1}`};
     opacity: 0.9;
     cursor: pointer;
     box-shadow: 2px 2px 10px #898989;

--- a/frontend/Idle/src/components/billPage/carMaster/MapModal.jsx
+++ b/frontend/Idle/src/components/billPage/carMaster/MapModal.jsx
@@ -94,7 +94,6 @@ function MapModal({ setCarMasterVisible }) {
           content: content,
           map: map.current,
           position: overlayPositon,
-          // image : item.imgUrl
         });
 
         overlays.push({ marker, overlay });
@@ -214,7 +213,7 @@ function MapModal({ setCarMasterVisible }) {
       <ModalBackground onClick={XBtnClicked} />
       <StContainer>
         <StBtnContainer>
-          <EscapeButton onClick={XBtnClicked} />
+          <EscapeButton alt={"XBtn"} onClick={XBtnClicked} />
         </StBtnContainer>
 
         <StMainContainer>

--- a/frontend/Idle/src/components/billPage/carMaster/MapModal.jsx
+++ b/frontend/Idle/src/components/billPage/carMaster/MapModal.jsx
@@ -11,14 +11,6 @@ import DealerBoxContainer from "./DealerBoxContainer";
 import Address from "./Address";
 import BlueButton from "../../common/buttons/BlueButton";
 import palette from "../../../styles/palette";
-// import BlueButton from "buttons/BlueButton";
-// import DillerBoxContainer from "./DillerBoxContainer";
-// import CategoryTabs from "tabs/CategoryTabs";
-// import { createPortal } from "react-dom";
-// import Address from "./Address";
-// import { DISTANCE, PATH, SALERATE } from "utils/constants";
-// import CustomOverlay from "./CustomOverlay";
-// import { getWithoutQueryAPI } from "utils/api";
 const { kakao } = window;
 
 let cachedData = null;
@@ -136,7 +128,6 @@ function MapModal({ setCarMasterVisible }) {
     }
   }, [data]);
 
-  //위치 수정시
   useEffect(() => {
     geocoder.coord2Address(longitude, latitude, function (result, status) {
       if (status === kakao.maps.services.Status.OK) {
@@ -149,19 +140,19 @@ function MapModal({ setCarMasterVisible }) {
     });
     selectedTab === SALERATE
       ? getWithoutQueryAPI(PATH.CARMASTER.SALERATE, {
-        nowLatitude: latitude,
-        nowLongitude: longitude,
-      }).then((res) => {
-        setData(res);
-        cachedData = res;
-      })
+          nowLatitude: latitude,
+          nowLongitude: longitude,
+        }).then((res) => {
+          setData(res);
+          cachedData = res;
+        })
       : getWithoutQueryAPI(PATH.CARMASTER.DISTANCE, {
-        nowLatitude: latitude,
-        nowLongitude: longitude,
-      }).then((res) => {
-        setData(res);
-        cachedData = res;
-      });
+          nowLatitude: latitude,
+          nowLongitude: longitude,
+        }).then((res) => {
+          setData(res);
+          cachedData = res;
+        });
   }, [latitude, longitude]);
 
   function XBtnClicked() {
@@ -170,19 +161,19 @@ function MapModal({ setCarMasterVisible }) {
   function TabClicked(name) {
     name === SALERATE
       ? getWithoutQueryAPI(PATH.CARMASTER.SALERATE, {
-        nowLatitude: latitude,
-        nowLongitude: longitude,
-      }).then((res) => {
-        setData(res);
-        cachedData = res;
-      })
+          nowLatitude: latitude,
+          nowLongitude: longitude,
+        }).then((res) => {
+          setData(res);
+          cachedData = res;
+        })
       : getWithoutQueryAPI(PATH.CARMASTER.DISTANCE, {
-        nowLatitude: latitude,
-        nowLongitude: longitude,
-      }).then((res) => {
-        setData(res);
-        cachedData = res;
-      });
+          nowLatitude: latitude,
+          nowLongitude: longitude,
+        }).then((res) => {
+          setData(res);
+          cachedData = res;
+        });
     setSelectedTab(name);
     setSelectedDealer("");
   }

--- a/frontend/Idle/src/components/carSelectionPage/CarSelectionBox.jsx
+++ b/frontend/Idle/src/components/carSelectionPage/CarSelectionBox.jsx
@@ -4,10 +4,10 @@ import palette from "../../styles/palette";
 function CarSelectionBox({ isSelected, data, setSelectedCar }) {
   return (
     <StContainer $isSelected={isSelected} onClick={() => setSelectedCar(data.carName)}>
-      <StImg src={data.carImgUrl}></StImg>
+      <StImg alt="CarImg" src={data.carImgUrl} />
       <StName>{data.carName}</StName>
       <StPrice>{data.carPrice.toLocaleString()} 만원~</StPrice>
-      {data.logoImgUrl && <StWheel src={data.logoImgUrl}></StWheel>}
+      {data.logoImgUrl && <StWheel alt={"logoImg"} src={data.logoImgUrl}></StWheel>}
       {data.carIsNew && <StNew>New</StNew>}
     </StContainer>
   );
@@ -32,7 +32,7 @@ const StContainer = styled.div`
 
   &:hover {
     background-color: ${({ $isSelected }) =>
-    $isSelected ? `${palette.NavyBlue_5}` : `${palette.NavyBlue_1}`};
+      $isSelected ? `${palette.NavyBlue_5}` : `${palette.NavyBlue_1}`};
     opacity: 0.9;
     cursor: pointer;
     box-shadow: 2px 2px 10px #898989;

--- a/frontend/Idle/src/components/colorPage/colorMain/Car3D.jsx
+++ b/frontend/Idle/src/components/colorPage/colorMain/Car3D.jsx
@@ -25,10 +25,10 @@ function Car3D({ data = null }) {
   function turnCar(e) {
     if (isMouseDown && e.clientX != beforeX) {
       if (e.clientX - beforeX > 2) {
-        turnRight()
+        turnRight();
         setBeforeX(e.clientX);
       } else if (beforeX - e.clientX > 2) {
-        turnLeft()
+        turnLeft();
         setBeforeX(e.clientX);
       }
     }
@@ -49,9 +49,13 @@ function Car3D({ data = null }) {
           onMouseUp={onMouseUp}
           onMouseLeave={onMouseUp}
         >
-          {data ? data[0]?.carImgUrls?.map((item, idx) => (
-            <StImage key={idx} src={item.imgUrl} $display={currentImg === idx} />
-          )) : <></>}
+          {data ? (
+            data[0]?.carImgUrls?.map((item, idx) => (
+              <StImage alt={"ItemImg"} key={idx} src={item.imgUrl} $display={currentImg === idx} />
+            ))
+          ) : (
+            <></>
+          )}
         </StImageContainer>
         <Circle />
         <Text>360도 돌려보세요!</Text>

--- a/frontend/Idle/src/components/colorPage/colorSub/InteriorColorBox.jsx
+++ b/frontend/Idle/src/components/colorPage/colorSub/InteriorColorBox.jsx
@@ -25,7 +25,7 @@ function InteriorColorBox({ data }) {
     >
       <StOutline $isSelected={data.interiorName === car.color.interior.name} />
       <StInnerImageContainer>
-        <StImage src={data.interiorImgUrl} />
+        <StImage alt="InteriorImg" src={data.interiorImgUrl} />
       </StInnerImageContainer>
       <StTextBox>
         <StTextTitle>{data.interiorName}</StTextTitle>
@@ -33,10 +33,10 @@ function InteriorColorBox({ data }) {
         <StTextPrice>+ {data.interiorPrice} 원</StTextPrice>
       </StTextBox>
     </StInnerColorBox>
-  )
+  );
 }
 
-export default InteriorColorBox
+export default InteriorColorBox;
 
 const StInnerColorBox = styled.div`
   box-sizing: border-box;

--- a/frontend/Idle/src/components/common/buttons/BlueButton.jsx
+++ b/frontend/Idle/src/components/common/buttons/BlueButton.jsx
@@ -29,8 +29,6 @@ const StButton = styled.button`
   background: ${palette.NavyBlue_5};
   color: ${palette.White};
   text-align: center;
-
-  /* body2 medium */
   font-family: "Hyundai Sans Text KR";
   font-size: 14px;
   font-style: normal;

--- a/frontend/Idle/src/components/common/buttons/LocationButton.jsx
+++ b/frontend/Idle/src/components/common/buttons/LocationButton.jsx
@@ -6,7 +6,7 @@ function LocationButton({ location }) {
   return (
     <StLocationContainer>
       {location}
-      <ArrowDown />
+      <ArrowDown alt={"ArrowDown"} />
     </StLocationContainer>
   );
 }

--- a/frontend/Idle/src/components/common/buttons/ModifyButton.jsx
+++ b/frontend/Idle/src/components/common/buttons/ModifyButton.jsx
@@ -2,12 +2,11 @@ import { styled } from "styled-components";
 import { ReactComponent as ArrowRight } from "../../../assets/images/arrowRight.svg";
 import palette from "../../../styles/palette";
 
-
 function ModifyButton({ onClick }) {
   return (
     <StContainer onClick={onClick}>
       <StTitle>변경하기</StTitle>
-      <StArrow />
+      <StArrow alt={"ArrowRight"} />
     </StContainer>
   );
 }

--- a/frontend/Idle/src/components/common/dropDown/OptionDropDown.jsx
+++ b/frontend/Idle/src/components/common/dropDown/OptionDropDown.jsx
@@ -47,7 +47,7 @@ function OptionDropDown({ category, optionData, modalPosition }) {
       <StTitle>
         {category.categoryName}
         <StButton $animationstate={animationstate}>
-          <ArrowDown />
+          <ArrowDown alt={"ArrowDown"} />
         </StButton>
       </StTitle>
       <StListContainer $isOpen={isOpen} $animationstate={animationstate}>

--- a/frontend/Idle/src/components/common/error/ErrorBoundary.jsx
+++ b/frontend/Idle/src/components/common/error/ErrorBoundary.jsx
@@ -21,7 +21,6 @@ class ErrorBoundary extends Component {
   }
   render(setError) {
     if (this.state.hasError) {
-      // 에러가 발생했을 때 대체 컴포넌트를 반환
       return <ServerErrorPage setError={setError} />;
     }
 

--- a/frontend/Idle/src/components/common/loading/Loading.jsx
+++ b/frontend/Idle/src/components/common/loading/Loading.jsx
@@ -1,32 +1,33 @@
 import { styled } from "styled-components";
 
 function Loading() {
-    return (
-        <StContainer>
-            <LoadingImage src="https://www.hyundai.com/static/images/pages/payment/Loading_Car.gif" />
-            잠시만 기다려 주세요
-        </StContainer>
-    )
+  return (
+    <StContainer>
+      <LoadingImage
+        alt="LoadingImg"
+        src="https://www.hyundai.com/static/images/pages/payment/Loading_Car.gif"
+      />
+      잠시만 기다려 주세요
+    </StContainer>
+  );
 }
 
-export default Loading
+export default Loading;
 
 const StContainer = styled.div`
-    display: flex;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;  
-    font-family: "Hyundai Sans Text KR";
-    font-size: 20px;
-    font-style: normal;
-    font-weight: 700;
-    line-height: 28px;
-    transform: translate(-50%,-50%);
-`
+  display: flex;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  font-family: "Hyundai Sans Text KR";
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 28px;
+  transform: translate(-50%, -50%);
+`;
 
-const LoadingImage = styled.img`
-    
-`
+const LoadingImage = styled.img``;

--- a/frontend/Idle/src/components/common/logos/MainLogoBlack.jsx
+++ b/frontend/Idle/src/components/common/logos/MainLogoBlack.jsx
@@ -33,7 +33,7 @@ function MainLogoBlack({ modalPosition = null }) {
 
   return (
     <Stdiv>
-      <MainLogoImg onClick={logoClicked} style={{ cursor: "pointer" }} />
+      <MainLogoImg alt="MainLogoImg" onClick={logoClicked} style={{ cursor: "pointer" }} />
       <Stdivision></Stdivision>
       <Stspan>마이 카마스터</Stspan>
       {modalVisible ? (

--- a/frontend/Idle/src/components/common/logos/MainLogoWhite.jsx
+++ b/frontend/Idle/src/components/common/logos/MainLogoWhite.jsx
@@ -11,7 +11,7 @@ function MainLogoWhite() {
 
   return (
     <Stdiv>
-      <MainLogoImg onClick={logoClicked} />
+      <MainLogoImg alt="MainLogoImg" onClick={logoClicked} />
       <Stdivision></Stdivision>
       <Stspan>마이 카마스터</Stspan>
     </Stdiv>

--- a/frontend/Idle/src/components/common/modals/OptionModal.jsx
+++ b/frontend/Idle/src/components/common/modals/OptionModal.jsx
@@ -19,7 +19,7 @@ function OptionModal({ title, description, functionImgUrl, onClose, modalPositio
         <StBox>
           <StTitle>
             {title}
-            <StCloseButton onClick={clickClose} />
+            <StCloseButton alt={"CloseButton"} onClick={clickClose} />
           </StTitle>
           <StImg $imgUrl={functionImgUrl} />
         </StBox>

--- a/frontend/Idle/src/components/common/modals/TrimOptionModal.jsx
+++ b/frontend/Idle/src/components/common/modals/TrimOptionModal.jsx
@@ -2,7 +2,7 @@ import { createPortal } from "react-dom";
 import { keyframes, styled } from "styled-components";
 import { useState } from "react";
 import { ReactComponent as EscapeButton } from "../../../assets/images/esc.svg";
-import OptionDropDown from "../../common/dropDown/OptionDropDown"
+import OptionDropDown from "../../common/dropDown/OptionDropDown";
 import palette from "../../../styles/palette";
 
 function TrimOptionModal({ trim, desc, setModalOff, defaultFunctions, modalPosition, optionData }) {
@@ -21,13 +21,18 @@ function TrimOptionModal({ trim, desc, setModalOff, defaultFunctions, modalPosit
           <StHeaderContainer>
             <StHeader>
               {trim}
-              <EscapeButton style={{ cursor: "pointer" }} onClick={modalOff} />
+              <EscapeButton alt={"EscapeButton"} style={{ cursor: "pointer" }} onClick={modalOff} />
             </StHeader>
             <Description>{desc}</Description>
           </StHeaderContainer>
           <StOptionContainer>
             {defaultFunctions.map((item, idx) => (
-              <OptionDropDown key={idx} category={item} optionData={optionData} modalPosition={modalPosition} />
+              <OptionDropDown
+                key={idx}
+                category={item}
+                optionData={optionData}
+                modalPosition={modalPosition}
+              />
             ))}
           </StOptionContainer>
         </StContainer>

--- a/frontend/Idle/src/components/common/toolTips/CarMasterTooltip.jsx
+++ b/frontend/Idle/src/components/common/toolTips/CarMasterTooltip.jsx
@@ -1,7 +1,7 @@
 import { ReactComponent as Tooltip } from "../../../assets/images/carMasterTooltip.svg";
 
 function CarMasterTooltip({ isActive }) {
-  return isActive ? <Tooltip /> : null;
+  return isActive ? <Tooltip alt={"CarMasterTooltip"} /> : null;
 }
 
 export default CarMasterTooltip;

--- a/frontend/Idle/src/components/common/toolTips/ConfusingTooltip.jsx
+++ b/frontend/Idle/src/components/common/toolTips/ConfusingTooltip.jsx
@@ -1,7 +1,7 @@
 import { ReactComponent as ConfusingTooltipIcon } from "../../../assets/images/confusingTooltip.svg";
 
 function ConfusingTooltip({ isActive }) {
-  return isActive ? <ConfusingTooltipIcon /> : null;
+  return isActive ? <ConfusingTooltipIcon alt={"ConfusingTooltip"} /> : null;
 }
 
 export default ConfusingTooltip;

--- a/frontend/Idle/src/components/common/toolTips/FindTrimTooltip.jsx
+++ b/frontend/Idle/src/components/common/toolTips/FindTrimTooltip.jsx
@@ -1,7 +1,7 @@
 import { ReactComponent as FindTrimTooltipIcon } from "../../../assets/images/findTrimTooltip.svg";
 
 function FindTrimTooltip({ isActive }) {
-  return isActive ? <FindTrimTooltipIcon /> : null;
+  return isActive ? <FindTrimTooltipIcon alt={"FindTrimTooltip"} /> : null;
 }
 
 export default FindTrimTooltip;

--- a/frontend/Idle/src/components/common/toolTips/OptionTooltip.jsx
+++ b/frontend/Idle/src/components/common/toolTips/OptionTooltip.jsx
@@ -1,7 +1,7 @@
 import { ReactComponent as OptionTooltipIcon } from "../../../assets/images/optionTooltip.svg";
 
 function OptionTooltip({ isActive }) {
-  return isActive ? <OptionTooltipIcon /> : null;
+  return isActive ? <OptionTooltipIcon alt={"OptionTooltip"} /> : null;
 }
 
 export default OptionTooltip;

--- a/frontend/Idle/src/components/detailModelPage/detailModelMain/EngineMain.jsx
+++ b/frontend/Idle/src/components/detailModelPage/detailModelMain/EngineMain.jsx
@@ -11,7 +11,7 @@ function EngineMain({ imgUrl, peakOutput, engineMaxTorque, minFuel, maxFuel }) {
   };
   return (
     <StContainer>
-      <StImage src={imgUrl} />
+      <StImage alt="EngineImg" src={imgUrl} />
       <StDetailContaier>
         {states.map((item, idx) => (
           <EngineDetail key={idx} state={item} data={formedData} />

--- a/frontend/Idle/src/components/navbar/NavbarBox.jsx
+++ b/frontend/Idle/src/components/navbar/NavbarBox.jsx
@@ -110,13 +110,14 @@ function renderChecked(type, currenPage, car) {
   //type , 현재 페이지, 카 객체
   const options = car[type];
 
-  if (currenPage === BILL && car.getAllOptionChecked() && clickedOptionPage) return <Checked />;
+  if (currenPage === BILL && car.getAllOptionChecked() && clickedOptionPage)
+    return <Checked alt={"Checked"} />;
 
   switch (type) {
     case TRIM:
-      return options.name !== undefined ? <Checked /> : null;
+      return options.name !== undefined ? <Checked alt={"Checked"} /> : null;
     case OPTION:
-      return clickedOptionPage ? <Checked /> : null;
+      return clickedOptionPage ? <Checked alt={"Checked"} /> : null;
     case BILL:
       break;
     default:

--- a/frontend/Idle/src/components/navbar/NavbarBox.jsx
+++ b/frontend/Idle/src/components/navbar/NavbarBox.jsx
@@ -4,14 +4,16 @@ import { useContext, useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { ReactComponent as Checked } from "../../assets/images/checked.svg";
 import { carContext } from "../../store/context";
-import { clickedOptionPage, TRIM, COLOR, DETAIL, OPTION, BILL, TYPE } from "../../constant/constants";
+import {
+  clickedOptionPage,
+  TRIM,
+  COLOR,
+  DETAIL,
+  OPTION,
+  BILL,
+  TYPE,
+} from "../../constant/constants";
 import palette from "../../styles/palette";
-/**
- *
- * @param {trim,color~~} type
- * @param {현재 무슨 페이지인지} currentPage
- * @param {setIsMatch} setIsMatch
- */
 function checkMatch(type, currentPage, setIsMatch) {
   if (currentPage.split("/").includes(type)) {
     setIsMatch(true);
@@ -20,12 +22,6 @@ function checkMatch(type, currentPage, setIsMatch) {
   }
 }
 
-/**
- *
- * @param {trim,color~~} type
- * @param {car[trim],car[color]~~} options
- * @returns option하나 하나
- */
 function renderOption(type, options) {
   let selectedOptions = [];
   switch (type) {
@@ -50,7 +46,6 @@ function renderOption(type, options) {
       keys.forEach((key) => {
         if (options[key].name !== undefined) selectedOptions.push(options[key].name);
       });
-    // selectedOptions[0] === undefined ? (selectedOptions = []) : selectedOptions;
   }
 
   if (type === DETAIL) {

--- a/frontend/Idle/src/components/navbar/NavbarBox.jsx
+++ b/frontend/Idle/src/components/navbar/NavbarBox.jsx
@@ -107,7 +107,6 @@ function boxClicked(type, navigate, car, setIsOpen, setIsEngineChekced) {
 }
 
 function renderChecked(type, currenPage, car) {
-  //type , 현재 페이지, 카 객체
   const options = car[type];
 
   if (currenPage === BILL && car.getAllOptionChecked() && clickedOptionPage)

--- a/frontend/Idle/src/components/optionPage/defaultOption/defaultOptionMain/DefaultOptionBox.jsx
+++ b/frontend/Idle/src/components/optionPage/defaultOption/defaultOptionMain/DefaultOptionBox.jsx
@@ -17,12 +17,12 @@ function DefaultOptionBox({ functionName, functionImgUrl, functionDescription })
         }}
       >
         <StImgContainer>
-          <StImg src={functionImgUrl} />
+          <StImg alt="OptionImg" src={functionImgUrl} />
         </StImgContainer>
         <StDescription>{functionName}</StDescription>
         <StDetailButton>
           자세히 보기
-          <ArrowRight />
+          <ArrowRight alt={"ArrowRight"} />
         </StDetailButton>
       </StContainer>
       {showDetail && (

--- a/frontend/Idle/src/components/optionPage/defaultOption/defaultOptionSub/CloseButton.jsx
+++ b/frontend/Idle/src/components/optionPage/defaultOption/defaultOptionSub/CloseButton.jsx
@@ -5,7 +5,7 @@ import palette from "../../../../styles/palette";
 function CloseButton({ onClick }) {
   return (
     <StButton onClick={onClick}>
-      <StArrowContainer />
+      <StArrowContainer alt={"ArrowDown"} />
       <StTextBox>추가 옵션 선택하기</StTextBox>
     </StButton>
   );
@@ -20,7 +20,7 @@ const StButton = styled.button`
   width: 99px;
   height: 28px;
   cursor: pointer;
-  &:hover{
+  &:hover {
     text-decoration: underline;
   }
 `;
@@ -42,19 +42,19 @@ const StTextBox = styled.div`
 `;
 
 const StArrowContainer = styled(StArrowDown)`
-position: relative;
-animation: bounceTop 1.3s infinite ease-in-out;
-@keyframes bounceTop {
-  0% {
-    top: -1px;
-  }
+  position: relative;
+  animation: bounceTop 1.3s infinite ease-in-out;
+  @keyframes bounceTop {
+    0% {
+      top: -1px;
+    }
 
-  50% {
-    top: 2px;
-  }
+    50% {
+      top: 2px;
+    }
 
-  100% {
-    top: -1px;
+    100% {
+      top: -1px;
+    }
   }
-}
-`
+`;

--- a/frontend/Idle/src/components/optionPage/defaultOption/defaultOptionSub/PaginationButton.jsx
+++ b/frontend/Idle/src/components/optionPage/defaultOption/defaultOptionSub/PaginationButton.jsx
@@ -6,11 +6,11 @@ function PaginationButton({ onClickPrev, onClickNext, currentPage, totalPages })
   return (
     <StContainer>
       <ArrowWrapper $visible={currentPage !== 1}>
-        <ArrowLeft onClick={onClickPrev} />
+        <ArrowLeft alt={"ArrowLeft"} onClick={onClickPrev} />
       </ArrowWrapper>
       <StNumber>{currentPage}</StNumber>
       <ArrowWrapper $visible={currentPage !== totalPages}>
-        <ArrowRight onClick={onClickNext} />
+        <ArrowRight alt={"ArrowRight"} onClick={onClickNext} />
       </ArrowWrapper>
     </StContainer>
   );

--- a/frontend/Idle/src/components/optionPage/optionMain/OptionContent.jsx
+++ b/frontend/Idle/src/components/optionPage/optionMain/OptionContent.jsx
@@ -24,7 +24,7 @@ function OptionContent({
   function renderWheelImg() {
     if (selectedFunction?.wheelLogoImgUrl === undefined) return;
     return selectedFunction?.wheelLogoImgUrl !== null ? (
-      <StWheelImg src={selectedFunction?.wheelLogoImgUrl} />
+      <StWheelImg alt="WheelImg" src={selectedFunction?.wheelLogoImgUrl} />
     ) : null;
   }
 

--- a/frontend/Idle/src/components/optionPage/optionMain/OptionFunctions.jsx
+++ b/frontend/Idle/src/components/optionPage/optionMain/OptionFunctions.jsx
@@ -17,8 +17,8 @@ function OptionFunctions({ optionData, setSelectedFunction, currentPage, setCurr
         ? setIsDescOverFlow(true)
         : setIsDescOverFlow(false)
       : ref.scrollWidth > ref.clientWidth
-        ? setIsFNameOverFlow(true)
-        : setIsFNameOverFlow(false);
+      ? setIsFNameOverFlow(true)
+      : setIsFNameOverFlow(false);
   }
 
   useEffect(() => {
@@ -58,13 +58,13 @@ function OptionFunctions({ optionData, setSelectedFunction, currentPage, setCurr
   function renderMain() {
     return optionData?.length > 1 ? (
       <StMain>
-        <ArrowLeft onClick={leftBtnClicked} style={{ cursor: "pointer" }} />
+        <ArrowLeft alt={"ArrowLeft"} onClick={leftBtnClicked} style={{ cursor: "pointer" }} />
         <StWrapper ref={fNameRef} $isOverFlow={isFNameOverFlow}>
           <StFunctionName $isOverFlow={isFNameOverFlow}>
             {optionData[currentPage]?.functionName}
           </StFunctionName>
         </StWrapper>
-        <ArrowRight onClick={rightBtnClicked} style={{ cursor: "pointer" }} />
+        <ArrowRight alt={"ArrowRight"} onClick={rightBtnClicked} style={{ cursor: "pointer" }} />
       </StMain>
     ) : null;
   }

--- a/frontend/Idle/src/components/optionPage/optionMain/OptionMain.jsx
+++ b/frontend/Idle/src/components/optionPage/optionMain/OptionMain.jsx
@@ -11,12 +11,9 @@ function OptionMain({
 }) {
   let filteredData;
   function filterData() {
-    //없으면 첫 데이터
     if (selectedOption === "") {
       filteredData = optionData[0];
-    }
-    //있으면 옵션에 해당하는 데이터
-    else {
+    } else {
       filteredData = optionData.filter((item) => item.optionName === selectedOption)[0];
     }
   }

--- a/frontend/Idle/src/components/optionPage/optionMain/OptionMain.jsx
+++ b/frontend/Idle/src/components/optionPage/optionMain/OptionMain.jsx
@@ -22,9 +22,9 @@ function OptionMain({
 
   function renderImg() {
     return selectedFunction === "" ? (
-      <StImg src={filteredData?.functions[0].functionImgUrl} />
+      <StImg alt="SelectedFunctionImg" src={filteredData?.functions[0].functionImgUrl} />
     ) : (
-      <StImg src={selectedFunction?.functionImgUrl} />
+      <StImg alt="SelectedFunctionImg" src={selectedFunction?.functionImgUrl} />
     );
   }
   return (

--- a/frontend/Idle/src/components/optionPage/optionSub/DefaultOptionButton.jsx
+++ b/frontend/Idle/src/components/optionPage/optionSub/DefaultOptionButton.jsx
@@ -5,7 +5,7 @@ import palette from "../../../styles/palette";
 function DefaultOptionButton({ onClick }) {
   return (
     <StButton onClick={onClick}>
-      <StArrowContainer />
+      <StArrowContainer alt={"ArrowUp"} />
       <StButtonText>기본 옵션 보기</StButtonText>
     </StButton>
   );
@@ -20,7 +20,7 @@ const StButton = styled.button`
   position: absolute;
   top: 90%;
   left: 47%;
-  &:hover{
+  &:hover {
     text-decoration: underline;
   }
 `;
@@ -33,19 +33,19 @@ const StButtonText = styled.div`
 `;
 
 const StArrowContainer = styled(ArrowUpper)`
-position: relative;
-animation: bounceTop 1.3s infinite ease-in-out;
-@keyframes bounceTop {
-  0% {
-    top: 1px;
-  }
+  position: relative;
+  animation: bounceTop 1.3s infinite ease-in-out;
+  @keyframes bounceTop {
+    0% {
+      top: 1px;
+    }
 
-  50% {
-    top: -2px;
-  }
+    50% {
+      top: -2px;
+    }
 
-  100% {
-    top: 1px;
+    100% {
+      top: 1px;
+    }
   }
-}
-`
+`;

--- a/frontend/Idle/src/components/trimPage/findTrim/findTrimSub/OptionBox.jsx
+++ b/frontend/Idle/src/components/trimPage/findTrim/findTrimSub/OptionBox.jsx
@@ -55,7 +55,7 @@ function OptionBox({ data, disable = false }) {
   return (
     <StContainer onClick={boxClicked} $isSelcted={isSelected} $disable={disable}>
       <StOption>
-        <OptionChecked data-name={data.name} />
+        <OptionChecked alt="OptionCheckedImg" data-name={data.name} />
         <StTitle $isSelcted={isSelected}>{dataNameCalc()}</StTitle>
       </StOption>
       <StBtn $isSelcted={isSelected} onClick={modalClicked}>
@@ -81,7 +81,7 @@ const StContainer = styled.div`
   align-items: center;
   &:hover {
     background-color: ${({ $isSelcted }) =>
-    $isSelcted ? `${palette.NavyBlue_5}` : `${palette.NavyBlue_1}`};
+      $isSelcted ? `${palette.NavyBlue_5}` : `${palette.NavyBlue_1}`};
     opacity: 0.9;
     cursor: pointer;
     box-shadow: 2px 2px 10px #898989;

--- a/frontend/Idle/src/components/trimPage/findTrim/findTrimSub/OptionSelectModal.jsx
+++ b/frontend/Idle/src/components/trimPage/findTrim/findTrimSub/OptionSelectModal.jsx
@@ -3,7 +3,7 @@ import { createPortal } from "react-dom";
 import { keyframes, styled } from "styled-components";
 import { dispatchContext, stateContext } from "../../../../store/context";
 import { PUSH_SELECTED_OPTION } from "../../../../store/actionType";
-import { optionModalWarningMent } from "../../../../constant/constants"
+import { optionModalWarningMent } from "../../../../constant/constants";
 import BlueButton from "../../../common/buttons/BlueButton";
 import palette from "../../../../styles/palette";
 import { ReactComponent as X } from "../../../../assets/images/esc.svg";
@@ -36,7 +36,7 @@ function OptionSelectModal({ data, setModalVisible, setIsSelected, onClick }) {
       <StContainer $animationstate={animationstate}>
         <StTitleContainer>
           <StTitle>{data.name}</StTitle>
-          <StImgX onClick={clickClose} data-name={"esc"} />
+          <StImgX alt="XImg" onClick={clickClose} data-name={"esc"} />
         </StTitleContainer>
         <StDescription>{data.description}</StDescription>
         <img

--- a/frontend/Idle/src/components/trimPage/trimMain/ExteriorBoxContainer.jsx
+++ b/frontend/Idle/src/components/trimPage/trimMain/ExteriorBoxContainer.jsx
@@ -1,25 +1,27 @@
-import { styled } from "styled-components"
+import { styled } from "styled-components";
 
 function ExteriorBoxContainer({ colors }) {
-    return (
-        <StContainer>
-            {colors.map((item, idx) => (<StImageBox key={idx} src={item.exteriorImgUrl} />))}
-        </StContainer>
-    )
+  return (
+    <StContainer>
+      {colors.map((item, idx) => (
+        <StImageBox alt="ExterirImg" key={idx} src={item.exteriorImgUrl} />
+      ))}
+    </StContainer>
+  );
 }
 
-export default ExteriorBoxContainer
+export default ExteriorBoxContainer;
 
 const StContainer = styled.div`
-    display: flex;
-    height: 34.165px;
-    justify-content: center;
-    align-items: center;
-    gap: 8px;
-`
+  display: flex;
+  height: 34.165px;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+`;
 
 const StImageBox = styled.img`
-    width: 20px;
-    height: 20px;
-    border-radius: 3px;
-`
+  width: 20px;
+  height: 20px;
+  border-radius: 3px;
+`;

--- a/frontend/Idle/src/components/trimPage/trimMain/InteriorBoxContainer.jsx
+++ b/frontend/Idle/src/components/trimPage/trimMain/InteriorBoxContainer.jsx
@@ -1,23 +1,25 @@
-import { styled } from "styled-components"
+import { styled } from "styled-components";
 
 function InteriorBoxContainer({ colors }) {
-    return (
-        <StContainer>
-            {colors.map((item, idx) => (<StImageBox key={idx} src={item.interiorImgUrl} />))}
-        </StContainer>
-    )
+  return (
+    <StContainer>
+      {colors.map((item, idx) => (
+        <StImageBox alt="InteriorImg" key={idx} src={item.interiorImgUrl} />
+      ))}
+    </StContainer>
+  );
 }
 
-export default InteriorBoxContainer
+export default InteriorBoxContainer;
 
 const StContainer = styled.div`
-    width:150px;
-`
+  width: 150px;
+`;
 
 const StImageBox = styled.img`
-    width: 61px;
-    height: 21px;
-    flex-shrink: 0;
-    margin: 0px 8px 0px 0px;
-    border-radius: 3px;
-`
+  width: 61px;
+  height: 21px;
+  flex-shrink: 0;
+  margin: 0px 8px 0px 0px;
+  border-radius: 3px;
+`;

--- a/frontend/Idle/src/components/trimPage/trimMain/TrimMain.jsx
+++ b/frontend/Idle/src/components/trimPage/trimMain/TrimMain.jsx
@@ -1,173 +1,191 @@
-import { useContext, useRef } from "react"
-import { styled } from "styled-components"
-import { carContext } from "../../../store/context"
+import { useContext, useRef } from "react";
+import { styled } from "styled-components";
+import { carContext } from "../../../store/context";
 import ExteriorBoxContainer from "./ExteriorBoxContainer";
 import InteriorBoxContainer from "./InteriorBoxContainer";
 
 function TrimMain({ data, onMouseEnter }) {
-    const { car } = useContext(carContext)
-    const dots = useRef([]);
-    const filteredData = data?.filter((item) => item.name === car.trim.name);
-    return (
-        <StContainer>
-            <StTitleContainer>
-                <StTitle>{car.trim.name}</StTitle>
-                <ColorContainer>
-                    <ExteriorContainer>
-                        외장
-                        {filteredData ? <ExteriorBoxContainer colors={filteredData[0].colors.exteriorImgUrls} /> : <></>}
-                    </ExteriorContainer>
-                    <InteriorContainer>
-                        내장
-                        {filteredData ? <InteriorBoxContainer colors={filteredData[0].colors.interiorImgUrls} /> : <></>}
-                    </InteriorContainer>
-                </ColorContainer>
-            </StTitleContainer>
-            {filteredData ? <StImage id={"here"} src={filteredData[0]?.imgUrl}></StImage> : <p>Loading...</p>}
-            <DotContainer >
-                {filteredData[0].thumbnailFunctions.map((item, idx) => (
-                    <Dot1 onMouseEnter={onMouseEnter} key={idx} $y={item.heightPixel} $x={item.widthPixel} ref={elem => (dots.current[idx] = elem)} >
-                        <InnerDots />
-                        <OptionToolTip className="tooltip">{item.name}</OptionToolTip>
-                    </Dot1>
-                ))}
-            </DotContainer>
-        </StContainer>
-    )
+  const { car } = useContext(carContext);
+  const dots = useRef([]);
+  const filteredData = data?.filter((item) => item.name === car.trim.name);
+  return (
+    <StContainer>
+      <StTitleContainer>
+        <StTitle>{car.trim.name}</StTitle>
+        <ColorContainer>
+          <ExteriorContainer>
+            외장
+            {filteredData ? (
+              <ExteriorBoxContainer colors={filteredData[0].colors.exteriorImgUrls} />
+            ) : (
+              <></>
+            )}
+          </ExteriorContainer>
+          <InteriorContainer>
+            내장
+            {filteredData ? (
+              <InteriorBoxContainer colors={filteredData[0].colors.interiorImgUrls} />
+            ) : (
+              <></>
+            )}
+          </InteriorContainer>
+        </ColorContainer>
+      </StTitleContainer>
+      {filteredData ? (
+        <StImage alt="FilteredDataImg" id={"here"} src={filteredData[0]?.imgUrl}></StImage>
+      ) : (
+        <p>Loading...</p>
+      )}
+      <DotContainer>
+        {filteredData[0].thumbnailFunctions.map((item, idx) => (
+          <Dot1
+            onMouseEnter={onMouseEnter}
+            key={idx}
+            $y={item.heightPixel}
+            $x={item.widthPixel}
+            ref={(elem) => (dots.current[idx] = elem)}
+          >
+            <InnerDots />
+            <OptionToolTip className="tooltip">{item.name}</OptionToolTip>
+          </Dot1>
+        ))}
+      </DotContainer>
+    </StContainer>
+  );
 }
 
-export default TrimMain
+export default TrimMain;
 
 const StContainer = styled.div`
-    position: absolute;
-    width: 809.378px;
-    height: 341.315px;
-    background: white;
-    top: 120px;
-    left: 130px;
-    flex-shrink: 0;
-    transition: all 0.2s ease;
-`
+  position: absolute;
+  width: 809.378px;
+  height: 341.315px;
+  background: white;
+  top: 120px;
+  left: 130px;
+  flex-shrink: 0;
+  transition: all 0.2s ease;
+`;
 
 const StTitleContainer = styled.div`
-    display: inline-flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 18px;
-`
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 18px;
+`;
 
 const StTitle = styled.div`
-    color: black;
-    font-family: "Hyundai Sans Head KR";
-    font-size: 28px;
-    font-style: normal;
-    font-weight: 500;
-    line-height: 36px;
-    letter-spacing: -0.84px;
-    transition: all 0.2s ease;
-`
+  color: black;
+  font-family: "Hyundai Sans Head KR";
+  font-size: 28px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 36px;
+  letter-spacing: -0.84px;
+  transition: all 0.2s ease;
+`;
 const ColorContainer = styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 16px;
-`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 16px;
+`;
 const ExteriorContainer = styled.div`
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    gap: 12px;
-    p{
-        color: black;
-        font-family: "Hyundai Sans Text KR";
-        font-size: 14px;
-        font-style: normal;
-        font-weight: 400;
-        line-height: 20px;
-        letter-spacing: -0.42px;
-    }   
-`
-const InteriorContainer = styled(ExteriorContainer)`
-    align-items: baseline;
-`
-
-const StImage = styled.img`
-    position: absolute;
-    width: 670px;
-    height: 380px;
-    right: 0;
-    bottom: 0;
-    transform: translate(5%,10%);
-`
-
-const DotContainer = styled.div`
-    position: absolute;
-    width: 670px;
-    height: 380px;
-    right: 0;
-    bottom: 0;
-    transform: translate(5%,10%);
-`
-const Dot1 = styled.div`
-    position: absolute;
-    top:${({ $y }) => `${$y}px`};
-    left: ${({ $x }) => `${$x}px`};
-    width: 20px;
-    height: 20px;
-    border-radius: 50%;
-    transform: translate(-50%,-50%);
-    cursor: pointer;
-    transition : all 0.3s ease-in-out;
-    background-color: #96A9DC;
-    filter: drop-shadow(0 0 0.2rem white);
-    &:hover > .tooltip,
-    &:active > .tooltip {
-        opacity: 1;
-        top: 5px;
-        opacity: 1;
-        visibility: visible;
-        pointer-events: auto;
-    }
-`
-const InnerDots = styled.div`
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    background-color: white;
-    transform: translate(50%,50%);
-`
-const OptionToolTip = styled.div`
-    opacity: 0;
-    pointer-events:none;
-    top: 10px;
-    position: absolute;
-    border-radius: 10px;
-    z-index: 1;
-    padding: 4px 12px;
-    background: var(--navy-blue-1, #E7ECF9);
-    align-items: flex-start;
-    gap: 8px;
-    width: max-content;
-    transform: translate(-42%,-130%);
-    color: var(--navy-blue-5, var(--navy-blue-5, #1A3276));
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 12px;
+  p {
+    color: black;
     font-family: "Hyundai Sans Text KR";
-    font-size: 13px;
+    font-size: 14px;
     font-style: normal;
     font-weight: 400;
-    line-height: 165%;
-    letter-spacing: -0.39px;
+    line-height: 20px;
+    letter-spacing: -0.42px;
+  }
+`;
+const InteriorContainer = styled(ExteriorContainer)`
+  align-items: baseline;
+`;
 
-    box-shadow: 0 10px 10px rgba(0, 0, 0, 0.1);
+const StImage = styled.img`
+  position: absolute;
+  width: 670px;
+  height: 380px;
+  right: 0;
+  bottom: 0;
+  transform: translate(5%, 10%);
+`;
+
+const DotContainer = styled.div`
+  position: absolute;
+  width: 670px;
+  height: 380px;
+  right: 0;
+  bottom: 0;
+  transform: translate(5%, 10%);
+`;
+const Dot1 = styled.div`
+  position: absolute;
+  top: ${({ $y }) => `${$y}px`};
+  left: ${({ $x }) => `${$x}px`};
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  cursor: pointer;
+  transition: all 0.3s ease-in-out;
+  background-color: #96a9dc;
+  filter: drop-shadow(0 0 0.2rem white);
+  &:hover > .tooltip,
+  &:active > .tooltip {
+    opacity: 1;
+    top: 5px;
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+  }
+`;
+const InnerDots = styled.div`
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: white;
+  transform: translate(50%, 50%);
+`;
+const OptionToolTip = styled.div`
+  opacity: 0;
+  pointer-events: none;
+  top: 10px;
+  position: absolute;
+  border-radius: 10px;
+  z-index: 1;
+  padding: 4px 12px;
+  background: var(--navy-blue-1, #e7ecf9);
+  align-items: flex-start;
+  gap: 8px;
+  width: max-content;
+  transform: translate(-42%, -130%);
+  color: var(--navy-blue-5, var(--navy-blue-5, #1a3276));
+  font-family: "Hyundai Sans Text KR";
+  font-size: 13px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 165%;
+  letter-spacing: -0.39px;
+
+  box-shadow: 0 10px 10px rgba(0, 0, 0, 0.1);
+  transition: all 0.3s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+  &::before {
+    position: absolute;
+    content: "";
+    height: 8px;
+    width: 8px;
+    background: #e7ecf9;
+    bottom: -3px;
+    left: 50%;
+    transform: translate(-50%) rotate(45deg);
     transition: all 0.3s cubic-bezier(0.68, -0.55, 0.265, 1.55);
-    &::before{
-        position: absolute;
-        content: "";
-        height: 8px;
-        width: 8px;
-        background: #E7ECF9;
-        bottom: -3px;
-        left: 50%;
-        transform: translate(-50%) rotate(45deg);
-        transition: all 0.3s cubic-bezier(0.68, -0.55, 0.265, 1.55);
-    }
-`
+  }
+`;

--- a/frontend/Idle/src/components/trimPage/trimSub/FindTrimButton.jsx
+++ b/frontend/Idle/src/components/trimPage/trimSub/FindTrimButton.jsx
@@ -5,7 +5,7 @@ import palette from "../../../styles/palette";
 function FindTrimButton({ onClick, onMouseEnter }) {
   return (
     <StFindTrimButton onClick={onClick}>
-      <StArrowContainer />
+      <StArrowContainer alt="ArrowLeftImg" />
       <StFindTrimButtonText onMouseEnter={onMouseEnter}>내게 맞는 트림 찾기</StFindTrimButtonText>
     </StFindTrimButton>
   );
@@ -34,19 +34,19 @@ const StFindTrimButtonText = styled.div`
 `;
 
 const StArrowContainer = styled(ArrowUpper)`
-position: relative;
-animation: bounceTop 1.3s infinite ease-in-out;
-@keyframes bounceTop {
-  0% {
-    top: 1px;
-  }
+  position: relative;
+  animation: bounceTop 1.3s infinite ease-in-out;
+  @keyframes bounceTop {
+    0% {
+      top: 1px;
+    }
 
-  50% {
-    top: -2px;
-  }
+    50% {
+      top: -2px;
+    }
 
-  100% {
-    top: 1px;
+    100% {
+      top: 1px;
+    }
   }
-}
-`
+`;

--- a/frontend/Idle/src/components/trimPage/trimSub/NormalTrimBox.jsx
+++ b/frontend/Idle/src/components/trimPage/trimSub/NormalTrimBox.jsx
@@ -75,7 +75,7 @@ function NormalTrimBox({
         </StContent>
         <PopUpButton $isSelected={isTrimSelected} onClick={setModalOn}>
           자세히 보기
-          <ArrorRight />
+          <ArrorRight alt="ArrowRightImg" />
         </PopUpButton>
       </StContainer>
       {isModal && (
@@ -120,7 +120,7 @@ const StContainer = styled.div`
   opacity: ${({ $isActive }) => ($isActive ? 1 : 0.2)};
   &:hover {
     background: ${({ $isSelected }) =>
-    $isSelected ? `${palette.NavyBlue_5}` : `${palette.NavyBlue_1}`};
+      $isSelected ? `${palette.NavyBlue_5}` : `${palette.NavyBlue_1}`};
     opacity: 0.9;
     cursor: pointer;
     box-shadow: 2px 2px 10px #898989;

--- a/frontend/Idle/src/pages/carSelectionPage.jsx
+++ b/frontend/Idle/src/pages/carSelectionPage.jsx
@@ -3,13 +3,13 @@ import { useNavigate } from "react-router-dom";
 import { getWithoutQueryAPI } from "../utils/api";
 import { PATH } from "../constant/path";
 import { styled } from "styled-components";
-import { CAR_SELECTION_NUM } from "../constant/constants"
-import CategoryTabs from "../components/common/tabs/CategoryTabs"
-import MainLogoBlack from "../components/common/logos/MainLogoBlack"
+import { CAR_SELECTION_NUM } from "../constant/constants";
+import CategoryTabs from "../components/common/tabs/CategoryTabs";
+import MainLogoBlack from "../components/common/logos/MainLogoBlack";
 import { ReactComponent as LeftArrow } from "../assets/images/optionArrowLeft.svg";
 import { ReactComponent as RightArrow } from "../assets/images/optionArrowRight.svg";
-import WarningModal from "../components/common/modals/WarningModal"
-import CarSelectionContainer from "../components/carSelectionPage/CarSelectionContainer"
+import WarningModal from "../components/common/modals/WarningModal";
+import CarSelectionContainer from "../components/carSelectionPage/CarSelectionContainer";
 import palette from "../styles/palette";
 
 function filterData(data, selectedTab, currentPage) {
@@ -97,11 +97,13 @@ function CarSelectionPage() {
 
         <StPage>
           <LeftArrow
+            alt="ArrowLeftImg"
             style={{ cursor: "pointer" }}
             onClick={() => leftBtnClicked(currentPage, setCurrentPage, maxPage)}
           />
           {currentPage}
           <RightArrow
+            alt="ArrowRightImg"
             style={{ cursor: "pointer" }}
             onClick={() => RightBtnClicked(currentPage, setCurrentPage, maxPage)}
           />

--- a/frontend/Idle/src/pages/optionPage.jsx
+++ b/frontend/Idle/src/pages/optionPage.jsx
@@ -1,11 +1,19 @@
 import { styled } from "styled-components";
 import { useContext, useLayoutEffect, useRef, useState } from "react";
-import { ALL, CONVENIENCE, PROTECTION, SAFETY, STYLE, TRANSLATE, setClickedOptionPage } from "../constant/constants"
-import { carContext } from "../store/context"
+import {
+  ALL,
+  CONVENIENCE,
+  PROTECTION,
+  SAFETY,
+  STYLE,
+  TRANSLATE,
+  setClickedOptionPage,
+} from "../constant/constants";
+import { carContext } from "../store/context";
 import { useNavigate, useParams } from "react-router-dom";
-import { getWithQueryAPI } from "../utils/api"
-import { PATH } from "../constant/path"
-import CategoryTabs from "../components/common/tabs/CategoryTabs"
+import { getWithQueryAPI } from "../utils/api";
+import { PATH } from "../constant/path";
+import CategoryTabs from "../components/common/tabs/CategoryTabs";
 import OptionMain from "../components/optionPage/optionMain/OptionMain";
 import { ReactComponent as ArrowLogo } from "../assets/images/arrowOption.svg";
 import WhiteButton from "../components/common/buttons/WhiteButton";
@@ -13,9 +21,9 @@ import BlueButton from "../components/common/buttons/BlueButton";
 import WarningModal from "../components/common/modals/WarningModal";
 import DefaultOptionButton from "../components/optionPage/optionSub/DefaultOptionButton";
 import DefaultOption from "../components/optionPage/defaultOption/DefaultOption";
-import palette from "../styles/palette"
+import palette from "../styles/palette";
 import OptionBoxContainer from "../components/optionPage/optionSub/OptionBoxContainer";
-import ConfusingTooltip from "../components/common/toolTips/ConfusingTooltip"
+import ConfusingTooltip from "../components/common/toolTips/ConfusingTooltip";
 
 const BLUR_STATUS = {
   LEFT_NONE: 1,
@@ -174,6 +182,7 @@ function OptionPage() {
           <StWrapper>
             <ArrowLeftContainer $blurState={blurState}>
               <ArrowLogo
+                alt="ArrowLogoImg"
                 onClick={() => {
                   ArrowButtonClicked("LEFT");
                 }}
@@ -184,10 +193,12 @@ function OptionPage() {
                 filteredData={filteredData}
                 selectedOption={selectedOption}
                 setSelectedOption={setSelectedOption}
-                setTooltipState={() => setTooltipState(false)} />
+                setTooltipState={() => setTooltipState(false)}
+              />
             </StContainer>
             <ArrowRightContainer $blurState={blurState}>
               <ArrowLogo
+                alt="ArrowLogoImg"
                 onClick={() => {
                   ArrowButtonClicked("RIGHT");
                 }}
@@ -232,9 +243,7 @@ function OptionPage() {
           modalPosition={"modal"}
         />
       ) : null}
-      {isDefaultModalOpen ? (
-        <DefaultOption setVisible={setIsDefaultModalOpen} />
-      ) : <></>}
+      {isDefaultModalOpen ? <DefaultOption setVisible={setIsDefaultModalOpen} /> : <></>}
     </>
   );
 }


### PR DESCRIPTION
## 🚩 관련 이슈
- close #348

## 📋 구현 기능 명세
- [x] 이미지 태그에 alt속성넣기
- [x] 이미지 컴포넌트들에 alt속성넣기

## 📌 PR Point
필요없는 주석들을 삭제했습니다.
모든 이미지 태그들과 ReactComponent as로 쓰는 이미지 컴포넌트들에 alt속성을 추가했습니다.

## 📸 결과물 스크린샷

<img width="552" alt="image" src="https://github.com/softeerbootcamp-2nd/A5-Idle/assets/84187086/cd84b1a6-7a60-4477-8806-7674592ede7e">

