### PR TITLE
[BE] @Transactionl 처리 및 추가 옵션 관련 쿼리 수정

### DIFF
--- a/backend/src/main/java/com/autoever/idle/domain/bill/service/BillService.java
+++ b/backend/src/main/java/com/autoever/idle/domain/bill/service/BillService.java
@@ -19,12 +19,14 @@ import com.autoever.idle.global.exception.custom.InvalidExteriorException;
 import com.autoever.idle.global.exception.custom.InvalidInteriorException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class BillService {
 
     private final TrimRepository trimRepository;

--- a/backend/src/main/java/com/autoever/idle/domain/carMaster/service/CarMasterService.java
+++ b/backend/src/main/java/com/autoever/idle/domain/carMaster/service/CarMasterService.java
@@ -5,6 +5,7 @@ import com.autoever.idle.domain.carMaster.repository.CarMasterRepository;
 import com.autoever.idle.global.exception.custom.InvalidLocationException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -12,6 +13,7 @@ import static com.autoever.idle.global.exception.ErrorCode.INVALID_LOCATION;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CarMasterService {
 
     private final CarMasterRepository carMasterRepository;

--- a/backend/src/main/java/com/autoever/idle/domain/carType/service/CarTypeService.java
+++ b/backend/src/main/java/com/autoever/idle/domain/carType/service/CarTypeService.java
@@ -7,12 +7,14 @@ import com.autoever.idle.domain.category.carCategory.dto.CarCategoryResponse;
 import com.autoever.idle.domain.category.carCategory.repository.CarCategoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CarTypeService {
 
     private final CarTypeRepository carTypeRepository;

--- a/backend/src/main/java/com/autoever/idle/domain/detailModel/DetailModelService.java
+++ b/backend/src/main/java/com/autoever/idle/domain/detailModel/DetailModelService.java
@@ -7,6 +7,7 @@ import com.autoever.idle.domain.detailModel.engine.repository.EngineRepository;
 import com.autoever.idle.global.exception.custom.InvalidDetailModelException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -15,6 +16,7 @@ import static com.autoever.idle.global.exception.ErrorCode.INVALID_DETAIL_MODEL;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class DetailModelService {
 
     private final EngineRepository engineRepository;

--- a/backend/src/main/java/com/autoever/idle/domain/exteriorColor/service/ExteriorColorService.java
+++ b/backend/src/main/java/com/autoever/idle/domain/exteriorColor/service/ExteriorColorService.java
@@ -6,12 +6,14 @@ import com.autoever.idle.domain.exteriorColor.dto.ExteriorColorResponse;
 import com.autoever.idle.domain.exteriorColor.repository.ExteriorColorRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ExteriorColorService {
 
 //    private static final String NEW = "NEW";

--- a/backend/src/main/java/com/autoever/idle/domain/function/service/FunctionService.java
+++ b/backend/src/main/java/com/autoever/idle/domain/function/service/FunctionService.java
@@ -4,12 +4,14 @@ import com.autoever.idle.domain.category.functionCategory.dto.DefaultFunctionCat
 import com.autoever.idle.domain.category.functionCategory.repository.FunctionCategoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class FunctionService {
 
     private final FunctionCategoryRepository functionCategoryRepository;

--- a/backend/src/main/java/com/autoever/idle/domain/interiorColor/service/InteriorColorService.java
+++ b/backend/src/main/java/com/autoever/idle/domain/interiorColor/service/InteriorColorService.java
@@ -7,6 +7,7 @@ import com.autoever.idle.domain.interiorColor.repository.InteriorColorRepository
 import com.autoever.idle.global.exception.custom.InvalidTrimException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -15,6 +16,7 @@ import static com.autoever.idle.global.exception.ErrorCode.INVALID_TRIM;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class InteriorColorService {
 
     private final InteriorColorRepository interiorColorRepository;

--- a/backend/src/main/java/com/autoever/idle/domain/myTrim/service/MyTrimService.java
+++ b/backend/src/main/java/com/autoever/idle/domain/myTrim/service/MyTrimService.java
@@ -14,6 +14,7 @@ import com.autoever.idle.global.exception.custom.InvalidMyTrimFunctionException;
 import com.autoever.idle.global.exception.custom.InvalidTrimFunctionException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,6 +24,7 @@ import static com.autoever.idle.global.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MyTrimService {
 
     private final FunctionRepository functionRepository;

--- a/backend/src/main/java/com/autoever/idle/domain/option/repository/OptionRepositoryImpl.java
+++ b/backend/src/main/java/com/autoever/idle/domain/option/repository/OptionRepositoryImpl.java
@@ -31,8 +31,8 @@ public class OptionRepositoryImpl implements OptionRepository {
         }
 
         query +=
-                "    THEN 'false' " +
-                        "    ELSE 'true' " +
+                "    THEN 'true' " +
+                        "    ELSE 'false' " +
                         "END AS optionCanSelect " +
                         "FROM FUNCTIONS f " +
                         "JOIN TRIM_FUNCTION tf ON f.function_id = tf.function_id " +

--- a/backend/src/main/java/com/autoever/idle/domain/option/service/OptionService.java
+++ b/backend/src/main/java/com/autoever/idle/domain/option/service/OptionService.java
@@ -7,12 +7,14 @@ import com.autoever.idle.domain.option.dto.OptionRequest;
 import com.autoever.idle.domain.option.repository.OptionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class OptionService {
     private final OptionRepository optionRepository;
     private final FunctionRepository functionRepository;

--- a/backend/src/main/java/com/autoever/idle/domain/trim/repository/TrimRepositoryImpl.java
+++ b/backend/src/main/java/com/autoever/idle/domain/trim/repository/TrimRepositoryImpl.java
@@ -26,7 +26,8 @@ public class TrimRepositoryImpl implements TrimRepository {
         return jdbcTemplate.query(
                 "select T.trim_id, T.name, T.price, T.img_url, T.description, T.purchase_rate from CAR_TYPE as CT " +
                         "left join TRIM as T on CT.car_type_id = T.car_type_id " +
-                        "where CT.name = :carTypeName",
+                        "where CT.name = :carTypeName " +
+                        "order by T.price",
                 param, rowMapper);
     }
 

--- a/backend/src/main/java/com/autoever/idle/domain/trim/service/TrimService.java
+++ b/backend/src/main/java/com/autoever/idle/domain/trim/service/TrimService.java
@@ -17,12 +17,14 @@ import com.autoever.idle.domain.trimThumbnailFunction.dto.TrimThumbnailFunctionR
 import com.autoever.idle.domain.trimThumbnailFunction.repository.TrimThumbnailFunctionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class TrimService {
 
     private final TrimRepository trimRepository;


### PR DESCRIPTION
## 🚩 관련 이슈
- close #355 
- close #360 

## 📋 구현 기능 명세
- [x] @Transactional(readOnly = true)
- [x] optionCanSelect 쿼리 수정

## 📌 PR Point
- 서비스 메서드 단위로 트랜잭션 읽기 전용으로 관리하도록 추가

